### PR TITLE
Fix CloudWatch Logs permissions and add comprehensive testing helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,8 @@ This is a .NET library that provides reusable AWS CDK constructs for serverless 
 # Build the solution
 dotnet build
 
-# Run all tests
-dotnet test
+# Run all tests (preferred method for xUnit v3)
+dotnet run --project test/LayeredCraft.Cdk.Constructs.Tests/ --framework net8.0
 
 # Run tests for a specific project
 dotnet test test/LayeredCraft.Cdk.Constructs.Tests/
@@ -83,6 +83,27 @@ dotnet add test/LayeredCraft.Cdk.Constructs.Tests/ package PackageName
 - Uses AutoFixture with custom configurations for realistic AWS resource names
 - Test assets include `test-lambda.zip` for Lambda deployment packages
 - Tests verify both resource creation and property configuration
+
+### Testing Helpers (`src/LayeredCraft.Cdk.Constructs/Testing/`)
+The library includes comprehensive testing helpers for consumers:
+
+**CdkTestHelper** (`CdkTestHelper.cs`):
+- `CreateTestStack()`: Creates CDK app and stack with test environment
+- `CreateTestStackMinimal()`: Creates only the stack (app created internally)
+- `GetTestAssetPath()`: Resolves test asset paths relative to executing assembly
+- `CreatePropsBuilder()`: Creates fluent builder with test defaults
+
+**LambdaFunctionConstructAssertions** (`LambdaFunctionConstructAssertions.cs`):
+- Extension methods for Template assertions
+- `ShouldHaveLambdaFunction()`, `ShouldHaveOtelLayer()`, `ShouldHaveCloudWatchLogsPermissions()`, etc.
+
+**LambdaFunctionConstructPropsBuilder** (`LambdaFunctionConstructPropsBuilder.cs`):
+- Fluent builder for creating test props with common AWS service integrations
+- Methods like `WithDynamoDbAccess()`, `WithS3Access()`, `WithApiGatewayPermission()`
+
+**Critical Testing Pattern**: 
+- Always create CDK templates AFTER adding constructs to stacks
+- Use `Template.FromStack(stack)` after construct creation, not before
 
 ## Development Practices
 

--- a/src/LayeredCraft.Cdk.Constructs/Constructs/LambdaFunctionConstruct.cs
+++ b/src/LayeredCraft.Cdk.Constructs/Constructs/LambdaFunctionConstruct.cs
@@ -26,7 +26,7 @@ public class LambdaFunctionConstruct : Construct
                         "logs:CreateLogGroup",
                         "logs:TagResource"
                     ],
-                    Resources = [$"arn:aws:logs:{region}:{account}:log-group:/aws/lambda/{props.FunctionName}*:*"],
+                    Resources = [$"arn:aws:logs:{region}:{account}:log-group:/aws/lambda/{props.FunctionName}-{props.FunctionSuffix}*:*"],
                     Effect = Effect.ALLOW
                 }),
                 new PolicyStatement(new PolicyStatementProps
@@ -36,7 +36,7 @@ public class LambdaFunctionConstruct : Construct
                         "logs:PutLogEvents"
                     ],
                     Resources =
-                        [$"arn:aws:logs:{region}:{account}:log-group:/aws/lambda/{props.FunctionName}*:*:*"],
+                        [$"arn:aws:logs:{region}:{account}:log-group:/aws/lambda/{props.FunctionName}-{props.FunctionSuffix}*:*:*"],
                     Effect = Effect.ALLOW
                 })
             ]

--- a/src/LayeredCraft.Cdk.Constructs/Testing/LambdaFunctionConstructAssertions.cs
+++ b/src/LayeredCraft.Cdk.Constructs/Testing/LambdaFunctionConstructAssertions.cs
@@ -1,0 +1,148 @@
+using Amazon.CDK.Assertions;
+
+namespace LayeredCraft.Cdk.Constructs.Testing;
+
+/// <summary>
+/// Extension methods for asserting LambdaFunctionConstruct resources in CDK templates.
+/// These helpers simplify common testing scenarios for consumers of the library.
+/// </summary>
+public static class LambdaFunctionConstructAssertions
+{
+    /// <summary>
+    /// Asserts that the template contains a Lambda function with the specified name.
+    /// </summary>
+    /// <param name="template">The CDK template to assert against</param>
+    /// <param name="functionName">The expected function name</param>
+    public static void ShouldHaveLambdaFunction(this Template template, string functionName)
+    {
+        template.HasResourceProperties("AWS::Lambda::Function", Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "FunctionName", functionName }
+        }));
+    }
+
+    /// <summary>
+    /// Asserts that the template contains CloudWatch Logs permissions for the specified function.
+    /// </summary>
+    /// <param name="template">The CDK template to assert against</param>
+    /// <param name="functionName">The function name to check permissions for</param>
+    /// <param name="region">AWS region (default: us-east-1)</param>
+    /// <param name="account">AWS account ID (default: 123456789012)</param>
+    public static void ShouldHaveCloudWatchLogsPermissions(this Template template, string functionName, 
+        string region = "us-east-1", string account = "123456789012")
+    {
+        template.HasResourceProperties("AWS::IAM::Policy", Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "PolicyDocument", Match.ObjectLike(new Dictionary<string, object>
+            {
+                { "Statement", Match.ArrayWith([
+                    // CloudWatch Logs permissions
+                    Match.ObjectLike(new Dictionary<string, object>
+                    {
+                        { "Effect", "Allow" },
+                        { "Action", Match.ArrayWith([
+                            "logs:CreateLogStream",
+                            "logs:CreateLogGroup", 
+                            "logs:TagResource"
+                        ]) },
+                        { "Resource", $"arn:aws:logs:{region}:{account}:log-group:/aws/lambda/{functionName}*:*" }
+                    }),
+                    Match.ObjectLike(new Dictionary<string, object>
+                    {
+                        { "Effect", "Allow" },
+                        { "Action", "logs:PutLogEvents" },
+                        { "Resource", $"arn:aws:logs:{region}:{account}:log-group:/aws/lambda/{functionName}*:*:*" }
+                    })
+                ]) }
+            }) }
+        }));
+    }
+
+    /// <summary>
+    /// Asserts that the template contains a Lambda function with OpenTelemetry layer and tracing enabled.
+    /// </summary>
+    /// <param name="template">The CDK template to assert against</param>
+    public static void ShouldHaveOtelLayer(this Template template)
+    {
+        template.HasResourceProperties("AWS::Lambda::Function", Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "TracingConfig", new Dictionary<string, object> { { "Mode", "Active" } } },
+            { "Layers", new object[] { Match.StringLikeRegexp(".*aws-otel-collector.*") } }
+        }));
+    }
+
+    /// <summary>
+    /// Asserts that the template contains a Lambda function without OpenTelemetry layer or tracing.
+    /// </summary>
+    /// <param name="template">The CDK template to assert against</param>
+    public static void ShouldNotHaveOtelLayer(this Template template)
+    {
+        // Verify TracingConfig is not present
+        template.HasResourceProperties("AWS::Lambda::Function", Match.Not(Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "TracingConfig", Match.AnyValue() }
+        })));
+
+        // Verify Layers property is not present
+        template.HasResourceProperties("AWS::Lambda::Function", Match.Not(Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "Layers", Match.AnyValue() }
+        })));
+    }
+
+    /// <summary>
+    /// Asserts that the template contains a Lambda function with the specified environment variables.
+    /// </summary>
+    /// <param name="template">The CDK template to assert against</param>
+    /// <param name="environmentVariables">The expected environment variables</param>
+    public static void ShouldHaveEnvironmentVariables(this Template template, IDictionary<string, string> environmentVariables)
+    {
+        template.HasResourceProperties("AWS::Lambda::Function", Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "Environment", Match.ObjectLike(new Dictionary<string, object>
+            {
+                { "Variables", Match.ObjectLike(environmentVariables.ToDictionary(kvp => kvp.Key, kvp => (object)kvp.Value)) }
+            }) }
+        }));
+    }
+
+    /// <summary>
+    /// Asserts that the template contains Lambda permissions for the specified count (function + version + alias).
+    /// </summary>
+    /// <param name="template">The CDK template to assert against</param>
+    /// <param name="permissionCount">Number of permission objects (will be multiplied by 3 for function, version, alias)</param>
+    public static void ShouldHaveLambdaPermissions(this Template template, int permissionCount)
+    {
+        var expectedPermissionCount = permissionCount * 3; // function + version + alias
+        template.ResourceCountIs("AWS::Lambda::Permission", expectedPermissionCount);
+    }
+
+    /// <summary>
+    /// Asserts that the template contains a Lambda version and alias.
+    /// </summary>
+    /// <param name="template">The CDK template to assert against</param>
+    /// <param name="aliasName">The expected alias name (default: live)</param>
+    public static void ShouldHaveVersionAndAlias(this Template template, string aliasName = "live")
+    {
+        template.ResourceCountIs("AWS::Lambda::Version", 1);
+        template.HasResourceProperties("AWS::Lambda::Alias", Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "Name", aliasName }
+        }));
+    }
+
+    /// <summary>
+    /// Asserts that the template contains a CloudWatch Logs log group with the specified retention.
+    /// </summary>
+    /// <param name="template">The CDK template to assert against</param>
+    /// <param name="functionName">The function name for the log group</param>
+    /// <param name="retentionDays">Expected retention in days (default: 14)</param>
+    public static void ShouldHaveLogGroup(this Template template, string functionName, int retentionDays = 14)
+    {
+        template.HasResourceProperties("AWS::Logs::LogGroup", Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "LogGroupName", $"/aws/lambda/{functionName}" },
+            { "RetentionInDays", retentionDays }
+        }));
+    }
+}

--- a/src/LayeredCraft.Cdk.Constructs/Testing/LambdaFunctionConstructPropsBuilder.cs
+++ b/src/LayeredCraft.Cdk.Constructs/Testing/LambdaFunctionConstructPropsBuilder.cs
@@ -1,0 +1,229 @@
+using Amazon.CDK.AWS.IAM;
+using LayeredCraft.Cdk.Constructs.Models;
+
+namespace LayeredCraft.Cdk.Constructs.Testing;
+
+/// <summary>
+/// Fluent builder for creating LambdaFunctionConstructProps instances in tests.
+/// Provides sensible defaults and allows customization of specific properties.
+/// </summary>
+public class LambdaFunctionConstructPropsBuilder
+{
+    private string _functionName = "test-function";
+    private string _functionSuffix = "test";
+    private string _assetPath = "./test-lambda.zip";
+    private string _roleName = "test-role";
+    private string _policyName = "test-policy";
+    private readonly List<PolicyStatement> _policyStatements = new();
+    private readonly Dictionary<string, string> _environmentVariables = new();
+    private bool _includeOtelLayer = true;
+    private readonly List<LambdaPermission> _permissions = new();
+
+    /// <summary>
+    /// Sets the function name.
+    /// </summary>
+    /// <param name="functionName">The function name</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public LambdaFunctionConstructPropsBuilder WithFunctionName(string functionName)
+    {
+        _functionName = functionName;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the function suffix.
+    /// </summary>
+    /// <param name="functionSuffix">The function suffix</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public LambdaFunctionConstructPropsBuilder WithFunctionSuffix(string functionSuffix)
+    {
+        _functionSuffix = functionSuffix;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the asset path for the Lambda deployment package.
+    /// </summary>
+    /// <param name="assetPath">The asset path</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public LambdaFunctionConstructPropsBuilder WithAssetPath(string assetPath)
+    {
+        _assetPath = assetPath;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the IAM role name.
+    /// </summary>
+    /// <param name="roleName">The role name</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public LambdaFunctionConstructPropsBuilder WithRoleName(string roleName)
+    {
+        _roleName = roleName;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the IAM policy name.
+    /// </summary>
+    /// <param name="policyName">The policy name</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public LambdaFunctionConstructPropsBuilder WithPolicyName(string policyName)
+    {
+        _policyName = policyName;
+        return this;
+    }
+
+    /// <summary>
+    /// Enables or disables the OpenTelemetry layer.
+    /// </summary>
+    /// <param name="enabled">Whether to include the OTEL layer</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public LambdaFunctionConstructPropsBuilder WithOtelEnabled(bool enabled = true)
+    {
+        _includeOtelLayer = enabled;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds DynamoDB access permissions for the specified table.
+    /// </summary>
+    /// <param name="tableName">The DynamoDB table name</param>
+    /// <param name="region">AWS region (default: us-east-1)</param>
+    /// <param name="account">AWS account ID (default: 123456789012)</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public LambdaFunctionConstructPropsBuilder WithDynamoDbAccess(string tableName, 
+        string region = "us-east-1", string account = "123456789012")
+    {
+        _policyStatements.Add(new PolicyStatement(new PolicyStatementProps
+        {
+            Actions = new[] { "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:Query", "dynamodb:UpdateItem", "dynamodb:DeleteItem" },
+            Resources = new[] { $"arn:aws:dynamodb:{region}:{account}:table/{tableName}" },
+            Effect = Effect.ALLOW
+        }));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds S3 access permissions for the specified bucket.
+    /// </summary>
+    /// <param name="bucketName">The S3 bucket name</param>
+    /// <param name="actions">S3 actions to allow (default: common read/write actions)</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public LambdaFunctionConstructPropsBuilder WithS3Access(string bucketName, 
+        string[]? actions = null)
+    {
+        actions ??= ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"];
+        
+        _policyStatements.Add(new PolicyStatement(new PolicyStatementProps
+        {
+            Actions = actions,
+            Resources = [$"arn:aws:s3:::{bucketName}/*"],
+            Effect = Effect.ALLOW
+        }));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds API Gateway invoke permission.
+    /// </summary>
+    /// <param name="apiArn">The API Gateway execution ARN</param>
+    /// <param name="eventSourceToken">Optional event source token</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public LambdaFunctionConstructPropsBuilder WithApiGatewayPermission(string apiArn, 
+        string? eventSourceToken = null)
+    {
+        _permissions.Add(new LambdaPermission
+        {
+            Principal = "apigateway.amazonaws.com",
+            Action = "lambda:InvokeFunction",
+            SourceArn = apiArn,
+            EventSourceToken = eventSourceToken
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// Adds Alexa Skills Kit invoke permission.
+    /// </summary>
+    /// <param name="skillId">The Alexa skill ID</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public LambdaFunctionConstructPropsBuilder WithAlexaPermission(string skillId)
+    {
+        _permissions.Add(new LambdaPermission
+        {
+            Principal = "alexa-appkit.amazon.com",
+            Action = "lambda:InvokeFunction",
+            EventSourceToken = skillId
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a custom policy statement.
+    /// </summary>
+    /// <param name="policyStatement">The policy statement to add</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public LambdaFunctionConstructPropsBuilder WithCustomPolicy(PolicyStatement policyStatement)
+    {
+        _policyStatements.Add(policyStatement);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a custom Lambda permission.
+    /// </summary>
+    /// <param name="permission">The Lambda permission to add</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public LambdaFunctionConstructPropsBuilder WithCustomPermission(LambdaPermission permission)
+    {
+        _permissions.Add(permission);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds an environment variable.
+    /// </summary>
+    /// <param name="key">The environment variable key</param>
+    /// <param name="value">The environment variable value</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public LambdaFunctionConstructPropsBuilder WithEnvironmentVariable(string key, string value)
+    {
+        _environmentVariables[key] = value;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds multiple environment variables.
+    /// </summary>
+    /// <param name="environmentVariables">Dictionary of environment variables</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public LambdaFunctionConstructPropsBuilder WithEnvironmentVariables(IDictionary<string, string> environmentVariables)
+    {
+        foreach (var kvp in environmentVariables)
+        {
+            _environmentVariables[kvp.Key] = kvp.Value;
+        }
+        return this;
+    }
+
+    /// <summary>
+    /// Builds the LambdaFunctionConstructProps instance.
+    /// </summary>
+    /// <returns>The configured LambdaFunctionConstructProps</returns>
+    public LambdaFunctionConstructProps Build()
+    {
+        return new LambdaFunctionConstructProps
+        {
+            FunctionName = _functionName,
+            FunctionSuffix = _functionSuffix,
+            AssetPath = _assetPath,
+            RoleName = _roleName,
+            PolicyName = _policyName,
+            PolicyStatements = _policyStatements.ToArray(),
+            EnvironmentVariables = _environmentVariables,
+            IncludeOtelLayer = _includeOtelLayer,
+            Permissions = _permissions
+        };
+    }
+}

--- a/test/LayeredCraft.Cdk.Constructs.Tests/Constructs/LambdaFunctionConstructTests.cs
+++ b/test/LayeredCraft.Cdk.Constructs.Tests/Constructs/LambdaFunctionConstructTests.cs
@@ -101,14 +101,14 @@ public class LambdaFunctionConstructTests
                             "logs:CreateLogGroup", 
                             "logs:TagResource"
                         ]) },
-                        { "Resource", $"arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/{props.FunctionName}*:*" }
+                        { "Resource", $"arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/{props.FunctionName}-{props.FunctionSuffix}*:*" }
                     }),
                     // Second statement: logs:PutLogEvents
                     Match.ObjectLike(new Dictionary<string, object>
                     {
                         { "Effect", "Allow" },
                         { "Action", "logs:PutLogEvents" },
-                        { "Resource", $"arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/{props.FunctionName}*:*:*" }
+                        { "Resource", $"arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/{props.FunctionName}-{props.FunctionSuffix}*:*:*" }
                     })
                 ]) }
             }) }

--- a/test/LayeredCraft.Cdk.Constructs.Tests/TestKit/Extensions/AssetPathExtensions.cs
+++ b/test/LayeredCraft.Cdk.Constructs.Tests/TestKit/Extensions/AssetPathExtensions.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+
+namespace LayeredCraft.Cdk.Constructs.Tests.TestKit.Extensions;
+
+/// <summary>
+/// Extension methods for resolving test asset paths relative to the executing assembly.
+/// </summary>
+public static class AssetPathExtensions
+{
+    /// <summary>
+    /// Gets the path to a test asset relative to the executing assembly location.
+    /// This ensures test assets can be found regardless of the current working directory.
+    /// </summary>
+    /// <param name="relativePath">Relative path from the test assembly location (e.g., "TestAssets/test-lambda.zip")</param>
+    /// <returns>Absolute path to the test asset</returns>
+    public static string GetTestAssetPath(string relativePath)
+    {
+        var assemblyLocation = Assembly.GetExecutingAssembly().Location;
+        var assemblyDirectory = Path.GetDirectoryName(assemblyLocation) ?? throw new InvalidOperationException("Could not determine assembly directory");
+        return Path.Combine(assemblyDirectory, relativePath);
+    }
+
+    /// <summary>
+    /// Gets the standard test Lambda deployment package path.
+    /// This is a convenience method for the most commonly used test asset.
+    /// </summary>
+    /// <returns>Absolute path to the test Lambda zip file</returns>
+    public static string GetTestLambdaZipPath()
+    {
+        return GetTestAssetPath("TestAssets/test-lambda.zip");
+    }
+}

--- a/test/LayeredCraft.Cdk.Constructs.Tests/Testing/TestingHelpersTests.cs
+++ b/test/LayeredCraft.Cdk.Constructs.Tests/Testing/TestingHelpersTests.cs
@@ -1,0 +1,205 @@
+using Amazon.CDK.Assertions;
+using AwesomeAssertions;
+using LayeredCraft.Cdk.Constructs.Constructs;
+using LayeredCraft.Cdk.Constructs.Testing;
+using LayeredCraft.Cdk.Constructs.Tests.TestKit.Extensions;
+
+namespace LayeredCraft.Cdk.Constructs.Tests.Testing;
+
+[Collection("CDK Tests")]
+public class TestingHelpersTests
+{
+    [Fact]
+    public void CdkTestHelper_ShouldCreateValidTestStack()
+    {
+        var stack = CdkTestHelper.CreateTestStackMinimal();
+
+        stack.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void PropsBuilder_ShouldCreateValidProps()
+    {
+        var props = CdkTestHelper.CreatePropsBuilder(AssetPathExtensions.GetTestLambdaZipPath())
+            .WithFunctionName("test-func")
+            .WithDynamoDbAccess("test-table")
+            .WithEnvironmentVariable("TEST_VAR", "test-value")
+            .Build();
+
+        props.FunctionName.Should().Be("test-func");
+        props.PolicyStatements.Should().HaveCount(1);
+        props.EnvironmentVariables.Should().ContainKey("TEST_VAR");
+        props.EnvironmentVariables["TEST_VAR"].Should().Be("test-value");
+    }
+
+    [Fact]
+    public void AssertionHelpers_ShouldWorkWithActualConstruct()
+    {
+        var stack = CdkTestHelper.CreateTestStackMinimal();
+
+        var props = CdkTestHelper.CreatePropsBuilder(AssetPathExtensions.GetTestLambdaZipPath())
+            .WithFunctionName("helper-test")
+            .WithFunctionSuffix("validation")
+            .WithOtelEnabled(true)
+            .Build();
+
+        _ = new LambdaFunctionConstruct(stack, "TestConstruct", props);
+
+        // Create template AFTER adding constructs to the stack
+        var template = Template.FromStack(stack);
+
+        // Test our assertion helpers work correctly
+        template.ShouldHaveLambdaFunction("helper-test-validation");
+        template.ShouldHaveOtelLayer();
+        template.ShouldHaveCloudWatchLogsPermissions("helper-test-validation");
+        template.ShouldHaveVersionAndAlias("live");
+        template.ShouldHaveLogGroup("helper-test-validation", 14);
+    }
+
+    [Fact]
+    public void AssertionHelpers_ShouldDetectMissingOtel()
+    {
+        var stack = CdkTestHelper.CreateTestStackMinimal();
+
+        var props = CdkTestHelper.CreatePropsBuilder(AssetPathExtensions.GetTestLambdaZipPath())
+            .WithOtelEnabled(false)
+            .Build();
+
+        _ = new LambdaFunctionConstruct(stack, "TestConstruct", props);
+
+        // Create template AFTER adding constructs to the stack
+        var template = Template.FromStack(stack);
+
+        template.ShouldNotHaveOtelLayer();
+    }
+
+    [Fact]
+    public void AssertionHelpers_ShouldVerifyEnvironmentVariables()
+    {
+        var stack = CdkTestHelper.CreateTestStackMinimal();
+
+        var expectedVars = new Dictionary<string, string>
+        {
+            { "API_URL", "https://api.example.com" },
+            { "LOG_LEVEL", "debug" },
+            { "FEATURE_FLAG", "enabled" }
+        };
+
+        var props = CdkTestHelper.CreatePropsBuilder(AssetPathExtensions.GetTestLambdaZipPath())
+            .WithFunctionName("env-test")
+            .WithEnvironmentVariables(expectedVars)
+            .Build();
+
+        _ = new LambdaFunctionConstruct(stack, "TestConstruct", props);
+
+        // Create template AFTER adding constructs to the stack
+        var template = Template.FromStack(stack);
+
+        template.ShouldHaveEnvironmentVariables(expectedVars);
+    }
+
+    [Fact]
+    public void AssertionHelpers_ShouldVerifyLambdaPermissions()
+    {
+        var stack = CdkTestHelper.CreateTestStackMinimal();
+
+        var props = CdkTestHelper.CreatePropsBuilder(AssetPathExtensions.GetTestLambdaZipPath())
+            .WithFunctionName("permission-test")
+            .WithApiGatewayPermission("arn:aws:execute-api:us-east-1:123456789012:abcdef123/prod/GET/test")
+            .WithAlexaPermission("amzn1.ask.skill.test-skill-id")
+            .Build();
+
+        _ = new LambdaFunctionConstruct(stack, "TestConstruct", props);
+
+        // Create template AFTER adding constructs to the stack
+        var template = Template.FromStack(stack);
+
+        // Should have 2 permissions * 3 targets (function + version + alias) = 6 total resources
+        template.ShouldHaveLambdaPermissions(2);
+    }
+
+    [Fact]
+    public void PropsBuilder_ShouldConfigureS3Access()
+    {
+        var props = CdkTestHelper.CreatePropsBuilder(AssetPathExtensions.GetTestLambdaZipPath())
+            .WithFunctionName("s3-test")
+            .WithS3Access("my-test-bucket")
+            .Build();
+
+        props.FunctionName.Should().Be("s3-test");
+        props.PolicyStatements.Should().HaveCount(1);
+        
+        var s3Statement = props.PolicyStatements[0];
+        s3Statement.Actions.Should().Contain("s3:GetObject");
+        s3Statement.Actions.Should().Contain("s3:PutObject");
+        s3Statement.Actions.Should().Contain("s3:DeleteObject");
+        s3Statement.Resources.Should().Contain("arn:aws:s3:::my-test-bucket/*");
+    }
+
+    [Fact]
+    public void PropsBuilder_ShouldAddCustomPolicy()
+    {
+        var customStatement = new Amazon.CDK.AWS.IAM.PolicyStatement(new Amazon.CDK.AWS.IAM.PolicyStatementProps
+        {
+            Actions = new[] { "sns:Publish" },
+            Resources = new[] { "arn:aws:sns:us-east-1:123456789012:my-topic" },
+            Effect = Amazon.CDK.AWS.IAM.Effect.ALLOW
+        });
+
+        var props = CdkTestHelper.CreatePropsBuilder(AssetPathExtensions.GetTestLambdaZipPath())
+            .WithFunctionName("custom-policy-test")
+            .WithCustomPolicy(customStatement)
+            .Build();
+
+        props.FunctionName.Should().Be("custom-policy-test");
+        props.PolicyStatements.Should().HaveCount(1);
+        
+        var snsStatement = props.PolicyStatements[0];
+        snsStatement.Actions.Should().Contain("sns:Publish");
+        snsStatement.Resources.Should().Contain("arn:aws:sns:us-east-1:123456789012:my-topic");
+    }
+
+    [Fact]
+    public void PropsBuilder_ShouldAddCustomPermission()
+    {
+        var customPermission = new LayeredCraft.Cdk.Constructs.Models.LambdaPermission
+        {
+            Principal = "events.amazonaws.com",
+            Action = "lambda:InvokeFunction",
+            SourceArn = "arn:aws:events:us-east-1:123456789012:rule/my-rule"
+        };
+
+        var props = CdkTestHelper.CreatePropsBuilder(AssetPathExtensions.GetTestLambdaZipPath())
+            .WithFunctionName("custom-permission-test")
+            .WithCustomPermission(customPermission)
+            .Build();
+
+        props.FunctionName.Should().Be("custom-permission-test");
+        props.Permissions.Should().HaveCount(1);
+        
+        var permission = props.Permissions[0];
+        permission.Principal.Should().Be("events.amazonaws.com");
+        permission.Action.Should().Be("lambda:InvokeFunction");
+        permission.SourceArn.Should().Be("arn:aws:events:us-east-1:123456789012:rule/my-rule");
+    }
+
+    [Fact]
+    public void CdkTestHelper_ShouldResolveTestAssetPath()
+    {
+        var assetPath = CdkTestHelper.GetTestAssetPath("TestAssets/custom-file.zip");
+        
+        assetPath.Should().NotBeNullOrEmpty();
+        assetPath.Should().EndWith("TestAssets/custom-file.zip");
+        Path.IsPathRooted(assetPath).Should().BeTrue("Should return absolute path");
+    }
+
+    [Fact]
+    public void CdkTestHelper_ShouldReturnStandardLambdaZipPath()
+    {
+        var zipPath = CdkTestHelper.GetTestLambdaZipPath();
+        
+        zipPath.Should().NotBeNullOrEmpty();
+        zipPath.Should().EndWith("TestAssets/test-lambda.zip");
+        Path.IsPathRooted(zipPath).Should().BeTrue("Should return absolute path");
+    }
+}


### PR DESCRIPTION
## Summary
- Fixed CloudWatch Logs policy to use full function name with suffix  
- Added comprehensive testing helpers for library consumers
- Enhanced documentation and examples

## Changes Made

### 🐛 Bug Fixes
- **Fixed CloudWatch Logs IAM policy**: Resource ARNs now correctly include function suffix (`function-name-suffix` instead of just `function-name`)
- **Updated existing tests**: Modified tests to match the corrected CloudWatch permissions pattern

### ✨ New Features
- **Testing Helpers Package**: Added comprehensive testing infrastructure in `src/LayeredCraft.Cdk.Constructs/Testing/`:
  - `CdkTestHelper`: Utilities for creating test stacks and resolving asset paths
  - `LambdaFunctionConstructAssertions`: Extension methods for CDK template assertions  
  - `LambdaFunctionConstructPropsBuilder`: Fluent builder for creating test props with AWS service integrations

### 📚 Documentation Updates
- **README.md**: Added comprehensive testing section with examples and assertion method documentation
- **CLAUDE.md**: Updated with testing infrastructure details and critical CDK template creation patterns
- **Examples**: Added examples showing correct CDK template creation timing

### 🧪 Test Coverage
Added comprehensive test coverage for:
- `ShouldHaveEnvironmentVariables` and `ShouldHaveLambdaPermissions` assertion methods
- `WithS3Access`, `WithCustomPolicy`, `WithCustomPermission` builder methods  
- `GetTestAssetPath` and `GetTestLambdaZipPath` utility methods

## Testing Helpers Usage

```csharp
// Create test infrastructure
var stack = CdkTestHelper.CreateTestStackMinimal();

// Build test props with fluent API
var props = CdkTestHelper.CreatePropsBuilder()
    .WithFunctionName("my-api")
    .WithDynamoDbAccess("users-table")
    .WithApiGatewayPermission("arn:aws:execute-api:us-east-1:123456789012:abc/prod/GET/users")
    .Build();

// Create construct and template
_ = new LambdaFunctionConstruct(stack, "TestLambda", props);
var template = Template.FromStack(stack); // CRITICAL: Create template AFTER construct

// Use assertion helpers
template.ShouldHaveLambdaFunction("my-api-test");
template.ShouldHaveCloudWatchLogsPermissions("my-api-test");
template.ShouldHaveEnvironmentVariables(expectedVars);
```

## Test Plan
- [x] All existing tests pass
- [x] New testing helper methods are fully tested
- [x] CloudWatch Logs permissions fixed and verified
- [x] Documentation examples are accurate
- [x] CDK template creation timing is correct

🤖 Generated with [Claude Code](https://claude.ai/code)