### PR TITLE
Add dual generic parameter methods to CdkTestHelper for exact type matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,41 @@ public void MyCustomStack_ShouldCreateInfrastructure()
 - **Clean Tests**: Eliminate boilerplate while maintaining flexibility
 - **Real-World Ready**: Works with any custom stack implementation
 
+### Example: Testing with Custom Stack Props Types
+
+For advanced scenarios where your custom stack expects specific props interfaces (not just `IStackProps`), you can use the dual-generic methods:
+
+```csharp
+[Fact]
+public void MyAdvancedStack_ShouldWorkWithCustomProps()
+{
+    // Custom props interface extending IStackProps
+    var customProps = new MyCustomStackProps
+    {
+        Env = new Environment { Account = "123456789012", Region = "us-east-1" },
+        Context = new MyContext { DatabaseUrl = "test-db-url" },
+        FeatureFlags = new Dictionary<string, bool> { { "EnableNewFeature", true } }
+    };
+
+    // Use dual generics for exact type matching - solves Activator.CreateInstance issues
+    var stack = CdkTestHelper.CreateTestStackMinimal<MyAdvancedStack, MyCustomStackProps>(
+        "advanced-test", customProps);
+
+    // Your stack gets the exact props type it expects
+    var template = Template.FromStack(stack);
+
+    // Test with full type safety
+    template.ShouldHaveLambdaFunction("advanced-function");
+    stack.DatabaseUrl.Should().Be("test-db-url"); // Custom props available
+    stack.IsNewFeatureEnabled.Should().Be(true);
+}
+```
+
+**When to Use Dual Generics:**
+- Your stack constructor expects a specific props interface (e.g., `ILightsaberStackProps`, `IInfraStackProps`)
+- You need exact type matching for `Activator.CreateInstance` to work correctly
+- You want full IntelliSense support for your custom props throughout the test
+
 ### Test Asset Management
 
 Create a `TestAssets` folder in your test project and place your Lambda deployment packages there:

--- a/src/LayeredCraft.Cdk.Constructs/Testing/CdkTestHelper.cs
+++ b/src/LayeredCraft.Cdk.Constructs/Testing/CdkTestHelper.cs
@@ -68,6 +68,25 @@ public static class CdkTestHelper
     }
 
     /// <summary>
+    /// Creates a test CDK app and custom stack type with the specified custom props type.
+    /// This method uses reflection to instantiate the custom stack type with custom props.
+    /// Note: You must create the Template.FromStack(stack) after adding constructs to the stack.
+    /// </summary>
+    /// <typeparam name="TStack">The custom stack type that inherits from Stack</typeparam>
+    /// <typeparam name="TProps">The custom props type that implements IStackProps</typeparam>
+    /// <param name="stackName">The name of the test stack</param>
+    /// <param name="stackProps">Custom stack props of type TProps</param>
+    /// <returns>Tuple containing the app and the custom stack instance</returns>
+    public static (App app, TStack stack) CreateTestStack<TStack, TProps>(string stackName, TProps stackProps) 
+        where TStack : Stack
+        where TProps : IStackProps
+    {
+        var app = new App();
+        var stack = (TStack)Activator.CreateInstance(typeof(TStack), app, stackName, stackProps)!;
+        return (app, stack);
+    }
+
+    /// <summary>
     /// Creates a test CDK stack (app is created internally).
     /// Note: You must create the Template.FromStack(stack) after adding constructs to the stack.
     /// </summary>
@@ -110,6 +129,24 @@ public static class CdkTestHelper
         where TStack : Stack
     {
         var (_, stack) = CreateTestStack<TStack>(stackName, stackProps);
+        return stack;
+    }
+
+    /// <summary>
+    /// Creates a test CDK custom stack type with the specified custom props type (app is created internally).
+    /// This method uses reflection to instantiate the custom stack type with custom props.
+    /// Note: You must create the Template.FromStack(stack) after adding constructs to the stack.
+    /// </summary>
+    /// <typeparam name="TStack">The custom stack type that inherits from Stack</typeparam>
+    /// <typeparam name="TProps">The custom props type that implements IStackProps</typeparam>
+    /// <param name="stackName">The name of the test stack</param>
+    /// <param name="stackProps">Custom stack props of type TProps</param>
+    /// <returns>The custom stack instance for testing</returns>
+    public static TStack CreateTestStackMinimal<TStack, TProps>(string stackName, TProps stackProps)
+        where TStack : Stack
+        where TProps : IStackProps
+    {
+        var (_, stack) = CreateTestStack<TStack, TProps>(stackName, stackProps);
         return stack;
     }
 


### PR DESCRIPTION
## Summary
- Add dual generic parameter methods `CreateTestStack<TStack, TProps>` and `CreateTestStackMinimal<TStack, TProps>` to CdkTestHelper
- Solve `Activator.CreateInstance` type matching issues when custom stack constructors expect specific props interfaces (not just `IStackProps`)
- Add comprehensive unit tests covering all dual generic method scenarios
- Update README.md with detailed "Testing with Custom Stack Props Types" section

## Technical Details
The new dual generic methods enable exact type matching for custom stack constructors that expect specific props interfaces. This solves issues where `Activator.CreateInstance` fails when trying to pass `IStackProps` to constructors expecting concrete interface types like `ILightsaberStackProps` or `IInfraStackProps`.

**New Methods Added:**
- `CreateTestStack<TStack, TProps>(string stackName, TProps stackProps)`
- `CreateTestStackMinimal<TStack, TProps>(string stackName, TProps stackProps)`

**When to Use:**
- Custom stack constructor expects specific props interface (e.g., `ILightsaberStackProps`)
- Need exact type matching for `Activator.CreateInstance`
- Want full IntelliSense support for custom props in tests

## Test Coverage
- Added comprehensive unit tests for all dual generic methods
- Created test helper classes: `TestAdvancedStack`, `ITestCustomStackProps`, `TestCustomStackProps`
- Integration tests showing end-to-end workflows with constructs
- Maintains backward compatibility with existing single generic methods

## Documentation Updates
- Added "Testing with Custom Stack Props Types" section to README.md
- Updated CLAUDE.md with new method signatures and usage examples
- Clear guidance on when to use dual generics vs single generics

🤖 Generated with [Claude Code](https://claude.ai/code)