### PR TITLE
Add AWS Lambda SnapStart support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ dotnet add test/LayeredCraft.Cdk.Constructs.Tests/ package PackageName
 - Main CDK construct that creates Lambda functions with comprehensive configuration
 - Automatically creates IAM roles and policies with CloudWatch Logs permissions
 - Supports OpenTelemetry layer integration via AWS managed layer
+- Supports AWS Lambda SnapStart for improved cold start performance
 - Creates function versions and aliases for deployment management
 - Handles Lambda permissions for multiple targets (function, version, alias)
 
@@ -97,11 +98,11 @@ The library includes comprehensive testing helpers for consumers:
 
 **LambdaFunctionConstructAssertions** (`LambdaFunctionConstructAssertions.cs`):
 - Extension methods for Template assertions
-- `ShouldHaveLambdaFunction()`, `ShouldHaveOtelLayer()`, `ShouldHaveCloudWatchLogsPermissions()`, etc.
+- `ShouldHaveLambdaFunction()`, `ShouldHaveOtelLayer()`, `ShouldHaveCloudWatchLogsPermissions()`, `ShouldHaveSnapStart()`, etc.
 
 **LambdaFunctionConstructPropsBuilder** (`LambdaFunctionConstructPropsBuilder.cs`):
 - Fluent builder for creating test props with common AWS service integrations
-- Methods like `WithDynamoDbAccess()`, `WithS3Access()`, `WithApiGatewayPermission()`
+- Methods like `WithDynamoDbAccess()`, `WithS3Access()`, `WithApiGatewayPermission()`, `WithSnapStart()`
 
 **Critical Testing Pattern**: 
 - Always create CDK templates AFTER adding constructs to stacks

--- a/README.md
+++ b/README.md
@@ -82,6 +82,24 @@ var lambdaConstruct = new LambdaFunctionConstruct(this, "MyLambda", new LambdaFu
 });
 ```
 
+### Lambda with SnapStart for Improved Performance
+
+```csharp
+var lambdaConstruct = new LambdaFunctionConstruct(this, "MyLambda", new LambdaFunctionConstructProps
+{
+    FunctionName = "my-function",
+    FunctionSuffix = "prod",
+    AssetPath = "./lambda-deployment.zip",
+    RoleName = "my-function-role",
+    PolicyName = "my-function-policy",
+    EnableSnapStart = true, // Enable SnapStart for faster cold starts
+    EnvironmentVariables = new Dictionary<string, string>
+    {
+        { "ENVIRONMENT", "production" }
+    }
+});
+```
+
 ## Features
 
 ### 🚀 LambdaFunctionConstruct
@@ -92,6 +110,7 @@ The main construct that creates a complete Lambda function setup with:
 - **IAM Role & Policy**: Automatic CloudWatch Logs permissions + custom policy statements
 - **CloudWatch Logs**: Explicit log group with configurable retention (default: 2 weeks)
 - **OpenTelemetry**: Optional AWS OTEL Collector layer integration
+- **SnapStart**: Optional AWS Lambda SnapStart for improved cold start performance
 - **Versioning**: Automatic version creation with "live" alias
 - **Multi-target Permissions**: Applies permissions to function, version, and alias
 
@@ -107,6 +126,7 @@ The main construct that creates a complete Lambda function setup with:
 | `PolicyStatements` | `PolicyStatement[]` | Custom IAM policy statements | `[]` |
 | `EnvironmentVariables` | `IDictionary<string, string>` | Environment variables | `{}` |
 | `IncludeOtelLayer` | `bool` | Enable OpenTelemetry layer | `true` |
+| `EnableSnapStart` | `bool` | Enable AWS Lambda SnapStart | `false` |
 | `Permissions` | `List<LambdaPermission>` | Lambda invocation permissions | `[]` |
 
 ### 🔍 OpenTelemetry Integration
@@ -336,6 +356,8 @@ var assetPath = CdkTestHelper.GetTestAssetPath("TestAssets/my-lambda.zip");
 | `ShouldHaveLambdaPermissions(count)` | Verify Lambda invoke permissions |
 | `ShouldHaveVersionAndAlias(aliasName)` | Verify versioning setup |
 | `ShouldHaveLogGroup(functionName, retentionDays)` | Verify log group configuration |
+| `ShouldHaveSnapStart()` | Verify SnapStart is enabled |
+| `ShouldNotHaveSnapStart()` | Verify SnapStart is disabled |
 
 ### Props Builder Methods
 
@@ -353,6 +375,7 @@ var assetPath = CdkTestHelper.GetTestAssetPath("TestAssets/my-lambda.zip");
 | `WithEnvironmentVariables(variables)` | Add multiple environment variables |
 | `WithCustomPolicy(policyStatement)` | Add custom IAM policy statement |
 | `WithCustomPermission(permission)` | Add custom Lambda permission |
+| `WithSnapStart(bool)` | Enable/disable Lambda SnapStart |
 
 ## Project Structure
 

--- a/src/LayeredCraft.Cdk.Constructs/Constructs/LambdaFunctionConstruct.cs
+++ b/src/LayeredCraft.Cdk.Constructs/Constructs/LambdaFunctionConstruct.cs
@@ -85,6 +85,15 @@ public class LambdaFunctionConstruct : Construct
         // ✅ Create a new version on every deployment
         var currentVersion = lambda.CurrentVersion;
 
+        if (props.EnableSnapStart)
+        {
+            var cfnFunction = (CfnFunction)lambda.Node.DefaultChild!;
+            cfnFunction.AddPropertyOverride("SnapStart", new Dictionary<string, object>
+            {
+                ["ApplyOn"] = "PublishedVersions"
+            });
+        }
+
         var alias = new Alias(this, $"{id}-alias", new AliasProps
         {
             AliasName = "live",

--- a/src/LayeredCraft.Cdk.Constructs/Models/LambdaFunctionConstructProps.cs
+++ b/src/LayeredCraft.Cdk.Constructs/Models/LambdaFunctionConstructProps.cs
@@ -13,6 +13,7 @@ public interface ILambdaFunctionConstructProps
     IDictionary<string, string> EnvironmentVariables { get; set; }
     bool IncludeOtelLayer { get; set; }
     List<LambdaPermission> Permissions { get; set; }
+    bool EnableSnapStart { get; set; }
 }
 public sealed record LambdaFunctionConstructProps : ILambdaFunctionConstructProps
 {
@@ -25,4 +26,5 @@ public sealed record LambdaFunctionConstructProps : ILambdaFunctionConstructProp
     public IDictionary<string, string> EnvironmentVariables { get; set; } = new Dictionary<string, string>();
     public bool IncludeOtelLayer { get; set; } = true;
     public List<LambdaPermission> Permissions { get; set; } = [];
+    public bool EnableSnapStart { get; set; } = false;
 }

--- a/src/LayeredCraft.Cdk.Constructs/Testing/LambdaFunctionConstructAssertions.cs
+++ b/src/LayeredCraft.Cdk.Constructs/Testing/LambdaFunctionConstructAssertions.cs
@@ -145,4 +145,31 @@ public static class LambdaFunctionConstructAssertions
             { "RetentionInDays", retentionDays }
         }));
     }
+
+    /// <summary>
+    /// Asserts that the template contains a Lambda function with SnapStart enabled.
+    /// </summary>
+    /// <param name="template">The CDK template to assert against</param>
+    public static void ShouldHaveSnapStart(this Template template)
+    {
+        template.HasResourceProperties("AWS::Lambda::Function", Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "SnapStart", Match.ObjectLike(new Dictionary<string, object>
+            {
+                { "ApplyOn", "PublishedVersions" }
+            }) }
+        }));
+    }
+
+    /// <summary>
+    /// Asserts that the template contains a Lambda function without SnapStart configuration.
+    /// </summary>
+    /// <param name="template">The CDK template to assert against</param>
+    public static void ShouldNotHaveSnapStart(this Template template)
+    {
+        template.HasResourceProperties("AWS::Lambda::Function", Match.Not(Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "SnapStart", Match.AnyValue() }
+        })));
+    }
 }

--- a/src/LayeredCraft.Cdk.Constructs/Testing/LambdaFunctionConstructPropsBuilder.cs
+++ b/src/LayeredCraft.Cdk.Constructs/Testing/LambdaFunctionConstructPropsBuilder.cs
@@ -18,6 +18,7 @@ public class LambdaFunctionConstructPropsBuilder
     private readonly Dictionary<string, string> _environmentVariables = new();
     private bool _includeOtelLayer = true;
     private readonly List<LambdaPermission> _permissions = new();
+    private bool _enableSnapStart = false;
 
     /// <summary>
     /// Sets the function name.
@@ -208,6 +209,17 @@ public class LambdaFunctionConstructPropsBuilder
     }
 
     /// <summary>
+    /// Enables or disables Lambda SnapStart.
+    /// </summary>
+    /// <param name="enabled">Whether to enable SnapStart</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public LambdaFunctionConstructPropsBuilder WithSnapStart(bool enabled = true)
+    {
+        _enableSnapStart = enabled;
+        return this;
+    }
+
+    /// <summary>
     /// Builds the LambdaFunctionConstructProps instance.
     /// </summary>
     /// <returns>The configured LambdaFunctionConstructProps</returns>
@@ -223,7 +235,8 @@ public class LambdaFunctionConstructPropsBuilder
             PolicyStatements = _policyStatements.ToArray(),
             EnvironmentVariables = _environmentVariables,
             IncludeOtelLayer = _includeOtelLayer,
-            Permissions = _permissions
+            Permissions = _permissions,
+            EnableSnapStart = _enableSnapStart
         };
     }
 }

--- a/test/LayeredCraft.Cdk.Constructs.Tests/Constructs/LambdaFunctionConstructTests.cs
+++ b/test/LayeredCraft.Cdk.Constructs.Tests/Constructs/LambdaFunctionConstructTests.cs
@@ -4,6 +4,7 @@ using AwesomeAssertions;
 using LayeredCraft.Cdk.Constructs.Constructs;
 using LayeredCraft.Cdk.Constructs.Models;
 using LayeredCraft.Cdk.Constructs.Tests.TestKit.Attributes;
+using LayeredCraft.Cdk.Constructs.Testing;
 
 namespace LayeredCraft.Cdk.Constructs.Tests.Constructs;
 
@@ -287,10 +288,7 @@ public class LambdaFunctionConstructTests
         var template = Template.FromStack(stack);
 
         // Verify that SnapStart is not configured by default
-        template.HasResourceProperties("AWS::Lambda::Function", Match.Not(Match.ObjectLike(new Dictionary<string, object>
-        {
-            { "SnapStart", Match.AnyValue() }
-        })));
+        template.ShouldNotHaveSnapStart();
     }
 
     [Theory]
@@ -309,12 +307,6 @@ public class LambdaFunctionConstructTests
         var template = Template.FromStack(stack);
 
         // Verify that SnapStart is enabled for published versions
-        template.HasResourceProperties("AWS::Lambda::Function", Match.ObjectLike(new Dictionary<string, object>
-        {
-            { "SnapStart", Match.ObjectLike(new Dictionary<string, object>
-            {
-                { "ApplyOn", "PublishedVersions" }
-            }) }
-        }));
+        template.ShouldHaveSnapStart();
     }
 }

--- a/test/LayeredCraft.Cdk.Constructs.Tests/Constructs/LambdaFunctionConstructTests.cs
+++ b/test/LayeredCraft.Cdk.Constructs.Tests/Constructs/LambdaFunctionConstructTests.cs
@@ -272,4 +272,49 @@ public class LambdaFunctionConstructTests
             { "RetentionInDays", 14 }
         }));
     }
+
+    [Theory]
+    [LambdaFunctionConstructAutoData]
+    public void Construct_ShouldNotEnableSnapStartByDefault(LambdaFunctionConstructProps props)
+    {
+        var app = new App();
+        var stack = new Stack(app, "test-stack", new StackProps
+        {
+            Env = new Amazon.CDK.Environment { Account = "123456789012", Region = "us-east-1" }
+        });
+        
+        _ = new LambdaFunctionConstruct(stack, "test-construct", props);
+        var template = Template.FromStack(stack);
+
+        // Verify that SnapStart is not configured by default
+        template.HasResourceProperties("AWS::Lambda::Function", Match.Not(Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "SnapStart", Match.AnyValue() }
+        })));
+    }
+
+    [Theory]
+    [LambdaFunctionConstructAutoData]
+    public void Construct_ShouldEnableSnapStartWhenConfigured(LambdaFunctionConstructProps props)
+    {
+        props.EnableSnapStart = true;
+        
+        var app = new App();
+        var stack = new Stack(app, "test-stack", new StackProps
+        {
+            Env = new Amazon.CDK.Environment { Account = "123456789012", Region = "us-east-1" }
+        });
+        
+        _ = new LambdaFunctionConstruct(stack, "test-construct", props);
+        var template = Template.FromStack(stack);
+
+        // Verify that SnapStart is enabled for published versions
+        template.HasResourceProperties("AWS::Lambda::Function", Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "SnapStart", Match.ObjectLike(new Dictionary<string, object>
+            {
+                { "ApplyOn", "PublishedVersions" }
+            }) }
+        }));
+    }
 }

--- a/test/LayeredCraft.Cdk.Constructs.Tests/TestKit/Customizations/LambdaFunctionConstructCustomization.cs
+++ b/test/LayeredCraft.Cdk.Constructs.Tests/TestKit/Customizations/LambdaFunctionConstructCustomization.cs
@@ -35,6 +35,7 @@ public class LambdaFunctionConstructCustomization(bool includeOtelLayer = true, 
             .With(props => props.IncludeOtelLayer, includeOtelLayer)
             .With(props => props.Permissions, includePermissions 
                 ? [fixture.Create<LambdaPermission>()]
-                : []));
+                : [])
+            .With(props => props.EnableSnapStart, false));
     }
 }


### PR DESCRIPTION
## Summary

- Add `EnableSnapStart` property to `LambdaFunctionConstructProps` (defaults to `false`)
- Implement SnapStart configuration using CloudFormation property override
- Add comprehensive test coverage for SnapStart functionality  
- Update testing helpers with SnapStart support
- Update documentation with SnapStart examples and configuration details

## Test plan

- [x] Unit tests pass for both enabled and disabled SnapStart configurations
- [x] Testing helpers work correctly with SnapStart scenarios
- [x] Documentation includes clear examples and configuration details
- [x] Backward compatibility maintained (SnapStart disabled by default)

🤖 Generated with [Claude Code](https://claude.ai/code)