### PR TITLE
Add StaticSiteConstruct for comprehensive static website hosting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a .NET library that provides reusable AWS CDK constructs for serverless applications. The library is designed specifically for LayeredCraft projects and focuses on Lambda functions with integrated OpenTelemetry support, IAM management, and environment configuration.
+This is a .NET library that provides reusable AWS CDK constructs for serverless applications and static websites. The library is designed specifically for LayeredCraft projects and includes:
+
+- **Lambda Functions**: Comprehensive Lambda construct with integrated OpenTelemetry support, IAM management, and environment configuration
+- **Static Sites**: Complete static website hosting with S3, CloudFront, SSL certificates, Route53 DNS, and optional API proxying
 
 ## Commands
 
@@ -47,9 +50,18 @@ dotnet add test/LayeredCraft.Cdk.Constructs.Tests/ package PackageName
 - Creates function versions and aliases for deployment management
 - Handles Lambda permissions for multiple targets (function, version, alias)
 
+**StaticSiteConstruct** (`src/LayeredCraft.Cdk.Constructs/Constructs/StaticSiteConstruct.cs`)
+- Comprehensive CDK construct for static website hosting
+- Creates S3 bucket with public access for website hosting
+- Sets up CloudFront distribution with SSL certificate and custom error pages
+- Configures Route53 DNS records for primary domain and alternates
+- Supports optional API proxying via CloudFront behaviors for `/api/*` paths
+- Includes automatic asset deployment with cache invalidation
+
 **Configuration Models** (`src/LayeredCraft.Cdk.Constructs/Models/`)
 - `LambdaFunctionConstructProps`: Main configuration interface and record for Lambda construct
 - `LambdaPermission`: Record for defining Lambda invocation permissions
+- `StaticSiteConstructProps`: Configuration interface and record for static site construct
 
 ### Key Design Patterns
 
@@ -78,12 +90,14 @@ dotnet add test/LayeredCraft.Cdk.Constructs.Tests/ package PackageName
 
 **Test Customizations**:
 - `LambdaFunctionConstructCustomization`: Configures realistic test data for Lambda constructs
-- Supports parameterized test scenarios (OTEL layer on/off, permissions included/excluded)
+- `StaticSiteConstructCustomization`: Configures realistic test data for static site constructs
+- Supports parameterized test scenarios for Lambda (OTEL layer on/off, permissions included/excluded) and static sites (API domain on/off, alternate domains included/excluded)
 
 ### Test Data Strategy
 - Uses AutoFixture with custom configurations for realistic AWS resource names
-- Test assets include `test-lambda.zip` for Lambda deployment packages
+- Test assets include `test-lambda.zip` for Lambda deployment packages and `static-site/` folder for static site assets
 - Tests verify both resource creation and property configuration
+- Supports parameterized scenarios for both Lambda (OTEL layer on/off, permissions included/excluded) and static sites (API domain on/off, alternate domains included/excluded)
 
 ### Testing Helpers (`src/LayeredCraft.Cdk.Constructs/Testing/`)
 The library includes comprehensive testing helpers for consumers:
@@ -94,7 +108,8 @@ The library includes comprehensive testing helpers for consumers:
 - `CreateTestStackMinimal()`: Creates only the stack (app created internally)  
 - `CreateTestStackMinimal<TStack>()`: Creates custom stack types with app created internally
 - `GetTestAssetPath()`: Resolves test asset paths relative to executing assembly
-- `CreatePropsBuilder()`: Creates fluent builder with test defaults
+- `CreatePropsBuilder()`: Creates fluent builder with Lambda test defaults
+- `CreateStaticSitePropsBuilder()`: Creates fluent builder with static site test defaults
 
 **LambdaFunctionConstructAssertions** (`LambdaFunctionConstructAssertions.cs`):
 - Extension methods for Template assertions
@@ -103,6 +118,14 @@ The library includes comprehensive testing helpers for consumers:
 **LambdaFunctionConstructPropsBuilder** (`LambdaFunctionConstructPropsBuilder.cs`):
 - Fluent builder for creating test props with common AWS service integrations
 - Methods like `WithDynamoDbAccess()`, `WithS3Access()`, `WithApiGatewayPermission()`, `WithSnapStart()`
+
+**StaticSiteConstructAssertions** (`StaticSiteConstructAssertions.cs`):
+- Extension methods for Template assertions specific to static sites
+- `ShouldHaveCompleteStaticSite()`, `ShouldHaveStaticWebsiteBucket()`, `ShouldHaveCloudFrontDistribution()`, `ShouldHaveSSLCertificate()`, `ShouldHaveRoute53Records()`, `ShouldHaveApiProxyBehavior()`, etc.
+
+**StaticSiteConstructPropsBuilder** (`StaticSiteConstructPropsBuilder.cs`):
+- Fluent builder for creating static site test props with scenario-based configurations
+- Methods like `WithDomainName()`, `WithAlternateDomains()`, `WithApiDomain()`, `ForBlog()`, `ForDocumentation()`, `ForSinglePageApp()`
 
 **Critical Testing Pattern**: 
 - Always create CDK templates AFTER adding constructs to stacks

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![NuGet](https://img.shields.io/nuget/v/LayeredCraft.Cdk.Constructs.svg)](https://www.nuget.org/packages/LayeredCraft.Cdk.Constructs/)
 [![Downloads](https://img.shields.io/nuget/dt/LayeredCraft.Cdk.Constructs.svg)](https://www.nuget.org/packages/LayeredCraft.Cdk.Constructs/)
 
-A reusable library of AWS CDK constructs for .NET projects, optimized for serverless applications using Lambda, API Gateway (or Lambda URLs), DynamoDB, S3, CloudFront, and OpenTelemetry. Built for speed, observability, and cost efficiency across the LayeredCraft project ecosystem.
+A reusable library of AWS CDK constructs for .NET projects, optimized for serverless applications and static websites. Features comprehensive Lambda functions with OpenTelemetry support, and complete static site hosting with CloudFront CDN, SSL certificates, and DNS management. Built for speed, observability, and cost efficiency across the LayeredCraft project ecosystem.
 
 ## Installation
 
@@ -114,6 +114,61 @@ The main construct that creates a complete Lambda function setup with:
 - **Versioning**: Automatic version creation with "live" alias
 - **Multi-target Permissions**: Applies permissions to function, version, and alias
 
+### 🌐 StaticSiteConstruct
+
+A comprehensive construct for hosting static websites with global content delivery:
+
+- **S3 Static Website**: Bucket configured for website hosting with proper public access
+- **CloudFront Distribution**: Global CDN with custom error pages and caching optimization
+- **SSL Certificate**: Automatic SSL/TLS certificate with DNS validation
+- **Route53 DNS**: A records with CloudFront alias targets for the domain and alternates
+- **Optional API Proxying**: Forward `/api/*` requests to a backend API domain
+- **Asset Deployment**: Automatic deployment of static assets with cache invalidation
+
+#### Quick Start - Static Site
+
+```csharp
+using Amazon.CDK;
+using LayeredCraft.Cdk.Constructs.Constructs;
+using LayeredCraft.Cdk.Constructs.Models;
+
+public class MyStack : Stack
+{
+    public MyStack(Construct scope, string id, IStackProps props = null) : base(scope, id, props)
+    {
+        var staticSite = new StaticSiteConstruct(this, "MySite", new StaticSiteConstructProps
+        {
+            DomainName = "example.com",
+            SiteSubDomain = "www",
+            AssetPath = "./build"
+        });
+    }
+}
+```
+
+#### Static Site with API Proxying
+
+```csharp
+var staticSite = new StaticSiteConstruct(this, "MySite", new StaticSiteConstructProps
+{
+    DomainName = "example.com",
+    SiteSubDomain = "app",
+    AssetPath = "./build",
+    ApiDomain = "api.example.com", // Proxy /api/* to this domain
+    AlternateDomains = new[] { "example.com", "www.example.com" }
+});
+```
+
+#### Static Site Configuration Options
+
+| Property | Type | Description | Default |
+|----------|------|-------------|---------|
+| `DomainName` | `string` | Root domain name (e.g., "example.com") | Required |
+| `SiteSubDomain` | `string` | Subdomain for the site (e.g., "www", "app") | Required |
+| `AssetPath` | `string` | Path to static assets directory | Required |
+| `ApiDomain` | `string?` | API domain for /api/* proxying | `null` |
+| `AlternateDomains` | `string[]` | Additional domains to serve content | `[]` |
+
 ### 🔧 Configuration Options
 
 | Property | Type | Description | Default |
@@ -153,6 +208,8 @@ The library includes comprehensive testing helpers to make it easy to unit test 
 - **`CdkTestHelper`**: Reduces boilerplate for creating test stacks and props (including custom stack types)
 - **`LambdaFunctionConstructAssertions`**: Extension methods for asserting Lambda resources
 - **`LambdaFunctionConstructPropsBuilder`**: Fluent builder for creating test props
+- **`StaticSiteConstructAssertions`**: Extension methods for asserting static site resources
+- **`StaticSiteConstructPropsBuilder`**: Fluent builder for creating static site test props
 
 ### Quick Testing Example
 
@@ -217,6 +274,65 @@ public void MyStack_ShouldCreateLegacyFunction()
     template.ShouldHaveLambdaFunction("legacy-function-test");
     template.ShouldNotHaveOtelLayer();
     template.ShouldHaveCloudWatchLogsPermissions("legacy-function-test");
+}
+```
+
+### Example: Testing StaticSiteConstruct
+
+```csharp
+using LayeredCraft.Cdk.Constructs.Constructs;
+using LayeredCraft.Cdk.Constructs.Testing;
+
+[Fact]
+public void MyStack_ShouldCreateStaticSiteWithApiProxy()
+{
+    // Create test infrastructure
+    var stack = CdkTestHelper.CreateTestStackMinimal();
+
+    // Build test props using fluent builder
+    var props = CdkTestHelper.CreateStaticSitePropsBuilder()
+        .WithDomainName("myapp.com")
+        .WithSiteSubDomain("app")
+        .WithApiDomain("api.myapp.com")
+        .WithAlternateDomains("myapp.com", "www.myapp.com")
+        .Build();
+
+    // Create the construct
+    _ = new StaticSiteConstruct(stack, "MyAppSite", props);
+
+    // Create template AFTER adding constructs to the stack
+    var template = Template.FromStack(stack);
+
+    // Use assertion helpers for clean, readable tests
+    template.ShouldHaveCompleteStaticSite("app.myapp.com", "app.myapp.com", 
+        hasApiProxy: true, domainCount: 3);
+    template.ShouldHaveApiProxyBehavior("api.myapp.com");
+    template.ShouldHaveRoute53Records("app.myapp.com");
+    template.ShouldHaveRoute53Records("myapp.com");
+    template.ShouldHaveRoute53Records("www.myapp.com");
+}
+```
+
+### Example: Testing Static Site Scenarios
+
+```csharp
+[Fact]
+public void MyStack_ShouldCreateBlogSite()
+{
+    var stack = CdkTestHelper.CreateTestStackMinimal();
+
+    var props = CdkTestHelper.CreateStaticSitePropsBuilder()
+        .ForBlog("myblog.com")
+        .Build();
+
+    _ = new StaticSiteConstruct(stack, "BlogSite", props);
+
+    var template = Template.FromStack(stack);
+
+    template.ShouldHaveCompleteStaticSite("www.myblog.com", "www.myblog.com", 
+        hasApiProxy: false, domainCount: 2);
+    template.ShouldHaveRoute53Records("www.myblog.com");
+    template.ShouldHaveRoute53Records("myblog.com");
 }
 ```
 
@@ -321,30 +437,41 @@ public class MyStack : Stack
 
 ### Test Asset Management
 
-Create a `TestAssets` folder in your test project and place your Lambda deployment packages there:
+Create a `TestAssets` folder in your test project and place your deployment packages there:
 
 ```
 YourTestProject/
 ├── TestAssets/
-│   ├── test-lambda.zip      # Default test asset
-│   └── my-custom-lambda.zip # Custom test assets
+│   ├── test-lambda.zip      # Default Lambda test asset
+│   ├── my-custom-lambda.zip # Custom Lambda test assets
+│   └── static-site/         # Static site test assets
+│       ├── index.html
+│       ├── styles.css
+│       └── script.js
 └── YourTests.cs
 ```
 
 The testing helpers automatically resolve test asset paths:
 
 ```csharp
-// Uses TestAssets/test-lambda.zip by default
-var props = CdkTestHelper.CreatePropsBuilder().Build();
+// Lambda testing - uses TestAssets/test-lambda.zip by default
+var lambdaProps = CdkTestHelper.CreatePropsBuilder().Build();
 
-// Or specify your own test asset
-var props = CdkTestHelper.CreatePropsBuilder("./TestAssets/my-custom-lambda.zip").Build();
+// Static site testing - uses TestAssets/static-site by default
+var staticProps = CdkTestHelper.CreateStaticSitePropsBuilder().Build();
+
+// Or specify your own test assets
+var customLambdaProps = CdkTestHelper.CreatePropsBuilder("./TestAssets/my-custom-lambda.zip").Build();
+var customStaticProps = CdkTestHelper.CreateStaticSitePropsBuilder("./TestAssets/my-site").Build();
 
 // Get reliable paths to test assets
-var assetPath = CdkTestHelper.GetTestAssetPath("TestAssets/my-lambda.zip");
+var lambdaAssetPath = CdkTestHelper.GetTestAssetPath("TestAssets/my-lambda.zip");
+var staticAssetPath = CdkTestHelper.GetTestAssetPath("TestAssets/my-site");
 ```
 
 ### Available Assertion Methods
+
+#### Lambda Function Assertions
 
 | Method | Description |
 |--------|-------------|
@@ -359,7 +486,23 @@ var assetPath = CdkTestHelper.GetTestAssetPath("TestAssets/my-lambda.zip");
 | `ShouldHaveSnapStart()` | Verify SnapStart is enabled |
 | `ShouldNotHaveSnapStart()` | Verify SnapStart is disabled |
 
+#### Static Site Assertions
+
+| Method | Description |
+|--------|-------------|
+| `ShouldHaveCompleteStaticSite(bucketName, domainName, hasApiProxy, domainCount)` | Verify complete static site setup |
+| `ShouldHaveStaticWebsiteBucket(bucketName)` | Verify S3 bucket with website configuration |
+| `ShouldHaveCloudFrontDistribution(domainName)` | Verify CloudFront distribution |
+| `ShouldHaveSSLCertificate(domainName)` | Verify SSL certificate |
+| `ShouldHaveRoute53Records(domainName)` | Verify Route53 A records |
+| `ShouldHaveMultipleRoute53Records(count)` | Verify multiple domain records |
+| `ShouldHaveApiProxyBehavior(apiDomain)` | Verify API proxy behavior |
+| `ShouldNotHaveApiProxyBehavior()` | Verify no API proxy behavior |
+| `ShouldHaveBucketDeployment()` | Verify asset deployment |
+
 ### Props Builder Methods
+
+#### Lambda Function Props Builder
 
 | Method | Description |
 |--------|-------------|
@@ -377,24 +520,45 @@ var assetPath = CdkTestHelper.GetTestAssetPath("TestAssets/my-lambda.zip");
 | `WithCustomPermission(permission)` | Add custom Lambda permission |
 | `WithSnapStart(bool)` | Enable/disable Lambda SnapStart |
 
+#### Static Site Props Builder
+
+| Method | Description |
+|--------|-------------|
+| `WithDomainName(domain)` | Set root domain name |
+| `WithSiteSubDomain(subdomain)` | Set site subdomain |
+| `WithAssetPath(path)` | Set static assets directory path |
+| `WithApiDomain(apiDomain)` | Set API domain for proxying |
+| `WithoutApiDomain()` | Remove API domain |
+| `WithAlternateDomain(domain)` | Add single alternate domain |
+| `WithAlternateDomains(domains...)` | Add multiple alternate domains |
+| `WithoutAlternateDomains()` | Clear all alternate domains |
+| `ForBlog(domain)` | Configure for blog scenario (www + naked domain) |
+| `ForDocumentation(domain, apiDomain)` | Configure for docs scenario with API |
+| `ForSinglePageApp(domain, apiDomain)` | Configure for SPA scenario with API |
+
 ## Project Structure
 
 ```
 ├── src/
 │   └── LayeredCraft.Cdk.Constructs/           # Main library package
 │       ├── Constructs/
-│       │   └── LambdaFunctionConstruct.cs      # Lambda function construct with IAM and logging
+│       │   ├── LambdaFunctionConstruct.cs      # Lambda function construct with IAM and logging
+│       │   └── StaticSiteConstruct.cs          # Static site construct with CDN and DNS
 │       ├── Models/
 │       │   ├── LambdaFunctionConstructProps.cs # Configuration props for Lambda construct
-│       │   └── LambdaPermission.cs             # Lambda permission model
+│       │   ├── LambdaPermission.cs             # Lambda permission model
+│       │   └── StaticSiteConstructProps.cs     # Configuration props for static site construct
 │       └── Testing/                            # Testing helpers for consumers
 │           ├── CdkTestHelper.cs                # Test stack and props creation utilities
-│           ├── LambdaFunctionConstructAssertions.cs # Extension methods for assertions
-│           └── LambdaFunctionConstructPropsBuilder.cs # Fluent builder for test props
+│           ├── LambdaFunctionConstructAssertions.cs # Extension methods for Lambda assertions
+│           ├── LambdaFunctionConstructPropsBuilder.cs # Fluent builder for Lambda test props
+│           ├── StaticSiteConstructAssertions.cs # Extension methods for static site assertions
+│           └── StaticSiteConstructPropsBuilder.cs # Fluent builder for static site test props
 ├── test/
 │   └── LayeredCraft.Cdk.Constructs.Tests/     # Test suite
 │       ├── Constructs/
-│       │   └── LambdaFunctionConstructTests.cs # Unit tests for Lambda construct
+│       │   ├── LambdaFunctionConstructTests.cs # Unit tests for Lambda construct
+│       │   └── StaticSiteConstructTests.cs     # Unit tests for static site construct
 │       ├── Testing/
 │       │   └── TestingHelpersTests.cs          # Tests for testing helper functionality
 │       ├── TestKit/                            # Test utilities and fixtures
@@ -402,7 +566,11 @@ var assetPath = CdkTestHelper.GetTestAssetPath("TestAssets/my-lambda.zip");
 │       │   ├── Customizations/                 # Test data customizations
 │       │   └── Extensions/                     # Test extension methods
 │       └── TestAssets/
-│           └── test-lambda.zip                 # Test Lambda deployment package
+│           ├── test-lambda.zip                 # Test Lambda deployment package
+│           └── static-site/                    # Test static site assets
+│               ├── index.html
+│               ├── styles.css
+│               └── script.js
 └── LayeredCraft.Cdk.Constructs.sln            # Solution file
 ```
 

--- a/README.md
+++ b/README.md
@@ -447,7 +447,8 @@ YourTestProject/
 │   └── static-site/         # Static site test assets
 │       ├── index.html
 │       ├── styles.css
-│       └── script.js
+│       ├── about.html
+│       └── app.js
 └── YourTests.cs
 ```
 
@@ -570,7 +571,8 @@ var staticAssetPath = CdkTestHelper.GetTestAssetPath("TestAssets/my-site");
 │           └── static-site/                    # Test static site assets
 │               ├── index.html
 │               ├── styles.css
-│               └── script.js
+│               ├── about.html
+│               └── app.js
 └── LayeredCraft.Cdk.Constructs.sln            # Solution file
 ```
 

--- a/src/LayeredCraft.Cdk.Constructs/Constructs/StaticSiteConstruct.cs
+++ b/src/LayeredCraft.Cdk.Constructs/Constructs/StaticSiteConstruct.cs
@@ -70,7 +70,7 @@ public class StaticSiteConstruct : Construct
         // Create CloudFront distribution for global content delivery
         var distribution = new Distribution(this, $"{id}-cdn", new DistributionProps
         {
-            DomainNames = ((string[]) [siteDomain]).Concat(props.AlternateDomains).ToArray(),
+            DomainNames = new[] { siteDomain }.Concat(props.AlternateDomains).ToArray(),
             DefaultBehavior = new BehaviorOptions
             {
                 Origin = new S3StaticWebsiteOrigin(siteBucket, new S3StaticWebsiteOriginProps

--- a/src/LayeredCraft.Cdk.Constructs/Constructs/StaticSiteConstruct.cs
+++ b/src/LayeredCraft.Cdk.Constructs/Constructs/StaticSiteConstruct.cs
@@ -1,0 +1,141 @@
+using Amazon.CDK;
+using Amazon.CDK.AWS.CertificateManager;
+using Amazon.CDK.AWS.CloudFront;
+using Amazon.CDK.AWS.CloudFront.Origins;
+using Amazon.CDK.AWS.Route53;
+using Amazon.CDK.AWS.Route53.Targets;
+using Amazon.CDK.AWS.S3;
+using Amazon.CDK.AWS.S3.Deployment;
+using Constructs;
+using LayeredCraft.Cdk.Constructs.Models;
+
+namespace LayeredCraft.Cdk.Constructs.Constructs;
+
+/// <summary>
+/// AWS CDK construct for creating a complete static website infrastructure.
+/// This construct creates an S3 bucket for hosting static content, CloudFront distribution for global content delivery,
+/// SSL certificate for HTTPS, and Route53 DNS records for domain configuration.
+/// Optionally supports API proxying through CloudFront behaviors.
+/// </summary>
+public class StaticSiteConstruct : Construct
+{
+    /// <summary>
+    /// Initializes a new instance of the StaticSiteConstruct class.
+    /// </summary>
+    /// <param name="scope">The parent construct</param>
+    /// <param name="id">The construct ID</param>
+    /// <param name="props">Configuration properties for the static site</param>
+    public StaticSiteConstruct(Construct scope, string id, IStaticSiteConstructProps props) : base(scope, id)
+    {
+        // Lookup existing Route53 hosted zone for the domain
+        var zone = HostedZone.FromLookup(this, id, new HostedZoneProviderProps
+        {
+            DomainName = props.DomainName
+        });
+
+        var siteDomain = $"{props.SiteSubDomain}.{props.DomainName}";
+        
+        // Create S3 bucket for static website hosting
+        var siteBucket = new Bucket(this, $"{id}-bucket", new BucketProps
+        {
+            BucketName = siteDomain,
+            WebsiteIndexDocument = "index.html",
+            WebsiteErrorDocument = "index.html",
+            PublicReadAccess = true,
+            BlockPublicAccess = new BlockPublicAccess(new BlockPublicAccessOptions
+            {
+                BlockPublicPolicy = false,
+                BlockPublicAcls = false,
+                IgnorePublicAcls = false,
+                RestrictPublicBuckets = false
+            }),
+            RemovalPolicy = RemovalPolicy.DESTROY,
+            Versioned = false,
+            AutoDeleteObjects = true,
+            LifecycleRules = [new LifecycleRule
+            {
+                Enabled = true,
+                NoncurrentVersionExpiration = Duration.Days(1)
+            }]
+        });
+
+        // Create SSL certificate for HTTPS with DNS validation
+        var certificate = new Certificate(this, $"{id}-certificate", new CertificateProps
+        {
+            DomainName = siteDomain,
+            Validation = CertificateValidation.FromDns(zone),
+            SubjectAlternativeNames = props.AlternateDomains,
+        });
+
+        // Create CloudFront distribution for global content delivery
+        var distribution = new Distribution(this, $"{id}-cdn", new DistributionProps
+        {
+            DomainNames = ((string[]) [siteDomain]).Concat(props.AlternateDomains).ToArray(),
+            DefaultBehavior = new BehaviorOptions
+            {
+                Origin = new S3StaticWebsiteOrigin(siteBucket, new S3StaticWebsiteOriginProps
+                {
+                    ProtocolPolicy = OriginProtocolPolicy.HTTP_ONLY
+                }),
+                AllowedMethods = AllowedMethods.ALLOW_GET_HEAD,
+                Compress = true
+            },
+            Certificate = certificate,
+            ErrorResponses =
+            [
+                new ErrorResponse
+                {
+                    HttpStatus = 403,
+                    ResponseHttpStatus = 200,
+                    ResponsePagePath = "/index.html"
+                }
+            ]
+        });
+
+        // Add API proxying behavior if API domain is specified
+        if (!string.IsNullOrWhiteSpace(props.ApiDomain))
+        {
+            distribution.AddBehavior("/api/*", new HttpOrigin(props.ApiDomain, new HttpOriginProps
+            {
+                ProtocolPolicy = OriginProtocolPolicy.HTTPS_ONLY
+            }), new BehaviorOptions
+            {
+                AllowedMethods = AllowedMethods.ALLOW_ALL,
+                CachePolicy = CachePolicy.CACHING_DISABLED,
+                OriginRequestPolicy = OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+                ViewerProtocolPolicy = ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+                Compress = true
+            });
+        }
+        
+        // Create primary DNS A record for the site domain
+        _ = new ARecord(this, $"{id}-alias-record", new ARecordProps
+        {
+            Zone = zone,
+            RecordName = siteDomain,
+            Target = RecordTarget.FromAlias(new CloudFrontTarget(distribution)),
+        });
+
+        // Create DNS A records for alternate domains
+        var counter = 0;
+        foreach (var domain in props.AlternateDomains)
+        {
+            _ = new ARecord(this, $"{id}-alias-record-{counter++}", new ARecordProps
+            {
+                Zone = zone,
+                RecordName = domain,
+                Target = RecordTarget.FromAlias(new CloudFrontTarget(distribution))
+            });
+        }
+
+        // Deploy static assets to S3 bucket and invalidate CloudFront cache
+        _ = new BucketDeployment(this, $"{id}-deployment", new BucketDeploymentProps
+        {
+            Sources = [Source.Asset(props.AssetPath)],
+            DestinationBucket = siteBucket,
+            Distribution = distribution,
+            DistributionPaths = ["/*"],
+            MemoryLimit = 1024
+        });
+    }
+}

--- a/src/LayeredCraft.Cdk.Constructs/Models/StaticSiteConstructProps.cs
+++ b/src/LayeredCraft.Cdk.Constructs/Models/StaticSiteConstructProps.cs
@@ -1,0 +1,52 @@
+namespace LayeredCraft.Cdk.Constructs.Models;
+
+/// <summary>
+/// Interface defining configuration properties for StaticSiteConstruct.
+/// Contains all required and optional settings for deploying a static website with CloudFront distribution.
+/// </summary>
+public interface IStaticSiteConstructProps
+{
+    /// <summary>
+    /// The root domain name for the static site (e.g., "example.com").
+    /// Must correspond to an existing Route53 hosted zone.
+    /// </summary>
+    string DomainName { get; set; }
+    /// <summary>
+    /// The subdomain for the static site (e.g., "www" for "www.example.com").
+    /// Combined with DomainName to form the full site domain.
+    /// </summary>
+    string SiteSubDomain { get; set; }
+    /// <summary>
+    /// Path to the static website assets that will be deployed to S3.
+    /// Can be a directory containing the built website files.
+    /// </summary>
+    string AssetPath { get; set; }
+    /// <summary>
+    /// Optional API domain for proxying API requests through CloudFront.
+    /// When specified, requests to /api/* will be forwarded to this domain.
+    /// </summary>
+    string? ApiDomain { get; set; }
+    /// <summary>
+    /// Additional domain names that should be included in the SSL certificate and CloudFront distribution.
+    /// Useful for supporting multiple domains or subdomains pointing to the same site.
+    /// </summary>
+    string[] AlternateDomains { get; set; }
+}
+
+/// <summary>
+/// Implementation record for StaticSiteConstruct configuration properties.
+/// Provides a concrete implementation of IStaticSiteConstructProps with sensible defaults.
+/// </summary>
+public record StaticSiteConstructProps : IStaticSiteConstructProps
+{
+    /// <inheritdoc />
+    public required string DomainName { get; set; }
+    /// <inheritdoc />
+    public required string SiteSubDomain { get; set; }
+    /// <inheritdoc />
+    public required string AssetPath { get; set; }
+    /// <inheritdoc />
+    public string? ApiDomain { get; set; }
+    /// <inheritdoc />
+    public string[] AlternateDomains { get; set; } = [];
+}

--- a/src/LayeredCraft.Cdk.Constructs/Testing/CdkTestHelper.cs
+++ b/src/LayeredCraft.Cdk.Constructs/Testing/CdkTestHelper.cs
@@ -1,6 +1,5 @@
 using System.Reflection;
 using Amazon.CDK;
-using Amazon.CDK.Assertions;
 
 namespace LayeredCraft.Cdk.Constructs.Testing;
 
@@ -199,5 +198,21 @@ public static class CdkTestHelper
             .WithPolicyName("test-function-policy")
             .WithEnvironmentVariable("ENVIRONMENT", "test")
             .WithOtelEnabled(true);
+    }
+
+    /// <summary>
+    /// Creates a StaticSiteConstructPropsBuilder with sensible test defaults.
+    /// Uses the executing assembly location to find test assets reliably.
+    /// </summary>
+    /// <param name="assetPath">Optional custom asset path. If not provided, uses TestAssets/static-site</param>
+    /// <returns>A configured builder for creating test props</returns>
+    public static StaticSiteConstructPropsBuilder CreateStaticSitePropsBuilder(string? assetPath = null)
+    {
+        var defaultAssetPath = assetPath ?? GetTestAssetPath("TestAssets/static-site");
+        
+        return new StaticSiteConstructPropsBuilder()
+            .WithDomainName("example.com")
+            .WithSiteSubDomain("www")
+            .WithAssetPath(defaultAssetPath);
     }
 }

--- a/src/LayeredCraft.Cdk.Constructs/Testing/StaticSiteConstructAssertions.cs
+++ b/src/LayeredCraft.Cdk.Constructs/Testing/StaticSiteConstructAssertions.cs
@@ -1,0 +1,222 @@
+using Amazon.CDK.Assertions;
+
+namespace LayeredCraft.Cdk.Constructs.Testing;
+
+/// <summary>
+/// Extension methods for asserting StaticSiteConstruct resources in CDK templates.
+/// These helpers simplify common testing scenarios for consumers of the library.
+/// </summary>
+public static class StaticSiteConstructAssertions
+{
+    /// <summary>
+    /// Asserts that the template contains an S3 bucket with static website hosting configuration.
+    /// </summary>
+    /// <param name="template">The CDK template to assert against</param>
+    /// <param name="bucketName">The expected bucket name</param>
+    public static void ShouldHaveStaticWebsiteBucket(this Template template, string bucketName)
+    {
+        template.HasResourceProperties("AWS::S3::Bucket", Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "BucketName", bucketName },
+            { "WebsiteConfiguration", Match.ObjectLike(new Dictionary<string, object>
+            {
+                { "IndexDocument", "index.html" },
+                { "ErrorDocument", "index.html" }
+            }) },
+            { "PublicAccessBlockConfiguration", Match.ObjectLike(new Dictionary<string, object>
+            {
+                { "BlockPublicPolicy", false },
+                { "BlockPublicAcls", false },
+                { "IgnorePublicAcls", false },
+                { "RestrictPublicBuckets", false }
+            }) }
+        }));
+    }
+
+    /// <summary>
+    /// Asserts that the template contains a CloudFront distribution with the specified domain.
+    /// </summary>
+    /// <param name="template">The CDK template to assert against</param>
+    /// <param name="domainName">The expected primary domain name</param>
+    public static void ShouldHaveCloudFrontDistribution(this Template template, string domainName)
+    {
+        template.HasResourceProperties("AWS::CloudFront::Distribution", Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "DistributionConfig", Match.ObjectLike(new Dictionary<string, object>
+            {
+                { "Aliases", Match.ArrayWith([domainName]) },
+                { "Enabled", true },
+                { "DefaultRootObject", Match.Absent() },
+                { "CustomErrorResponses", Match.ArrayWith([
+                    Match.ObjectLike(new Dictionary<string, object>
+                    {
+                        { "ErrorCode", 403 },
+                        { "ResponseCode", 200 },
+                        { "ResponsePagePath", "/index.html" }
+                    })
+                ]) }
+            }) }
+        }));
+    }
+
+    /// <summary>
+    /// Asserts that the template contains a CloudFront distribution with API behavior for /api/* paths.
+    /// </summary>
+    /// <param name="template">The CDK template to assert against</param>
+    /// <param name="apiDomain">The expected API domain</param>
+    public static void ShouldHaveApiProxyBehavior(this Template template, string apiDomain)
+    {
+        template.HasResourceProperties("AWS::CloudFront::Distribution", Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "DistributionConfig", Match.ObjectLike(new Dictionary<string, object>
+            {
+                { "CacheBehaviors", Match.ArrayWith([
+                    Match.ObjectLike(new Dictionary<string, object>
+                    {
+                        { "PathPattern", "/api/*" },
+                        { "TargetOriginId", Match.AnyValue() },
+                        { "ViewerProtocolPolicy", "redirect-to-https" },
+                        { "AllowedMethods", Match.AnyValue() },
+                        { "CachePolicyId", Match.AnyValue() },
+                        { "OriginRequestPolicyId", Match.AnyValue() },
+                        { "Compress", true }
+                    })
+                ]) }
+            }) }
+        }));
+
+        // Also verify the HTTP origin exists for the API domain
+        template.HasResourceProperties("AWS::CloudFront::Distribution", Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "DistributionConfig", Match.ObjectLike(new Dictionary<string, object>
+            {
+                { "Origins", Match.ArrayWith([
+                    Match.ObjectLike(new Dictionary<string, object>
+                    {
+                        { "DomainName", apiDomain },
+                        { "CustomOriginConfig", Match.ObjectLike(new Dictionary<string, object>
+                        {
+                            { "OriginProtocolPolicy", "https-only" }
+                        }) }
+                    })
+                ]) }
+            }) }
+        }));
+    }
+
+    /// <summary>
+    /// Asserts that the template does not contain API proxy behavior (no /api/* cache behaviors).
+    /// </summary>
+    /// <param name="template">The CDK template to assert against</param>
+    public static void ShouldNotHaveApiProxyBehavior(this Template template)
+    {
+        // Check that there are no cache behaviors for /api/*
+        template.HasResourceProperties("AWS::CloudFront::Distribution", Match.Not(Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "DistributionConfig", Match.ObjectLike(new Dictionary<string, object>
+            {
+                { "CacheBehaviors", Match.ArrayWith([
+                    Match.ObjectLike(new Dictionary<string, object>
+                    {
+                        { "PathPattern", "/api/*" }
+                    })
+                ]) }
+            }) }
+        })));
+    }
+
+    /// <summary>
+    /// Asserts that the template contains an SSL certificate for the specified domain.
+    /// </summary>
+    /// <param name="template">The CDK template to assert against</param>
+    /// <param name="domainName">The expected primary domain name</param>
+    public static void ShouldHaveSSLCertificate(this Template template, string domainName)
+    {
+        template.HasResourceProperties("AWS::CertificateManager::Certificate", Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "DomainName", domainName },
+            { "ValidationMethod", "DNS" }
+        }));
+    }
+
+    /// <summary>
+    /// Asserts that the template contains Route53 A records for the specified domain.
+    /// </summary>
+    /// <param name="template">The CDK template to assert against</param>
+    /// <param name="domainName">The expected domain name</param>
+    public static void ShouldHaveRoute53Records(this Template template, string domainName)
+    {
+        template.HasResourceProperties("AWS::Route53::RecordSet", Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "Name", $"{domainName}." },
+            { "Type", "A" },
+            { "AliasTarget", Match.ObjectLike(new Dictionary<string, object>
+            {
+                { "DNSName", Match.AnyValue() },
+                { "HostedZoneId", Match.AnyValue() }
+            }) }
+        }));
+    }
+
+    /// <summary>
+    /// Asserts that the template contains multiple Route53 A records for alternate domains.
+    /// </summary>
+    /// <param name="template">The CDK template to assert against</param>
+    /// <param name="domainCount">Expected number of domain records (primary + alternates)</param>
+    public static void ShouldHaveMultipleRoute53Records(this Template template, int domainCount)
+    {
+        template.ResourceCountIs("AWS::Route53::RecordSet", domainCount);
+    }
+
+    /// <summary>
+    /// Asserts that the template contains a bucket deployment for static assets.
+    /// CDK BucketDeployment creates a Custom::CDKBucketDeployment resource, not AWS::S3::BucketDeployment.
+    /// </summary>
+    /// <param name="template">The CDK template to assert against</param>
+    public static void ShouldHaveBucketDeployment(this Template template)
+    {
+        template.HasResourceProperties("Custom::CDKBucketDeployment", Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "DestinationBucketName", Match.AnyValue() },
+            { "SourceBucketNames", Match.AnyValue() },
+            { "DistributionId", Match.AnyValue() },
+            { "DistributionPaths", Match.ArrayWith(["/*"]) }
+        }));
+    }
+
+    /// <summary>
+    /// Asserts that the template contains all expected resources for a complete static site.
+    /// </summary>
+    /// <param name="template">The CDK template to assert against</param>
+    /// <param name="bucketName">The expected S3 bucket name</param>
+    /// <param name="domainName">The expected primary domain name</param>
+    /// <param name="hasApiProxy">Whether API proxy behavior should be present</param>
+    /// <param name="domainCount">Expected number of domain records</param>
+    public static void ShouldHaveCompleteStaticSite(this Template template, string bucketName, string domainName, 
+        bool hasApiProxy = false, int domainCount = 1)
+    {
+        template.ShouldHaveStaticWebsiteBucket(bucketName);
+        template.ShouldHaveCloudFrontDistribution(domainName);
+        template.ShouldHaveSSLCertificate(domainName);
+        template.ShouldHaveRoute53Records(domainName);
+        template.ShouldHaveMultipleRoute53Records(domainCount);
+        template.ShouldHaveBucketDeployment();
+
+        if (hasApiProxy)
+        {
+            // Note: API domain assertion would need the actual API domain value
+            // This is a simplified check for cache behavior existence
+            template.HasResourceProperties("AWS::CloudFront::Distribution", Match.ObjectLike(new Dictionary<string, object>
+            {
+                { "DistributionConfig", Match.ObjectLike(new Dictionary<string, object>
+                {
+                    { "CacheBehaviors", Match.AnyValue() }
+                }) }
+            }));
+        }
+        else
+        {
+            template.ShouldNotHaveApiProxyBehavior();
+        }
+    }
+}

--- a/src/LayeredCraft.Cdk.Constructs/Testing/StaticSiteConstructPropsBuilder.cs
+++ b/src/LayeredCraft.Cdk.Constructs/Testing/StaticSiteConstructPropsBuilder.cs
@@ -1,0 +1,160 @@
+using LayeredCraft.Cdk.Constructs.Models;
+
+namespace LayeredCraft.Cdk.Constructs.Testing;
+
+/// <summary>
+/// Fluent builder for creating StaticSiteConstructProps instances in tests.
+/// Provides sensible defaults and allows customization of specific properties.
+/// </summary>
+public class StaticSiteConstructPropsBuilder
+{
+    private string _domainName = "example.com";
+    private string _siteSubDomain = "www";
+    private string _assetPath = "./test-static-site";
+    private string? _apiDomain = null;
+    private readonly List<string> _alternateDomains = new();
+
+    /// <summary>
+    /// Sets the root domain name.
+    /// </summary>
+    /// <param name="domainName">The root domain name</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public StaticSiteConstructPropsBuilder WithDomainName(string domainName)
+    {
+        _domainName = domainName;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the site subdomain.
+    /// </summary>
+    /// <param name="siteSubDomain">The site subdomain</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public StaticSiteConstructPropsBuilder WithSiteSubDomain(string siteSubDomain)
+    {
+        _siteSubDomain = siteSubDomain;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the asset path for the static website files.
+    /// </summary>
+    /// <param name="assetPath">The asset path</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public StaticSiteConstructPropsBuilder WithAssetPath(string assetPath)
+    {
+        _assetPath = assetPath;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the API domain for proxying API requests.
+    /// </summary>
+    /// <param name="apiDomain">The API domain</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public StaticSiteConstructPropsBuilder WithApiDomain(string apiDomain)
+    {
+        _apiDomain = apiDomain;
+        return this;
+    }
+
+    /// <summary>
+    /// Removes the API domain (sets to null).
+    /// </summary>
+    /// <returns>The builder instance for method chaining</returns>
+    public StaticSiteConstructPropsBuilder WithoutApiDomain()
+    {
+        _apiDomain = null;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds an alternate domain to the list.
+    /// </summary>
+    /// <param name="alternateDomain">The alternate domain to add</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public StaticSiteConstructPropsBuilder WithAlternateDomain(string alternateDomain)
+    {
+        _alternateDomains.Add(alternateDomain);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds multiple alternate domains to the list.
+    /// </summary>
+    /// <param name="alternateDomains">The alternate domains to add</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public StaticSiteConstructPropsBuilder WithAlternateDomains(params string[] alternateDomains)
+    {
+        _alternateDomains.AddRange(alternateDomains);
+        return this;
+    }
+
+    /// <summary>
+    /// Clears all alternate domains.
+    /// </summary>
+    /// <returns>The builder instance for method chaining</returns>
+    public StaticSiteConstructPropsBuilder WithoutAlternateDomains()
+    {
+        _alternateDomains.Clear();
+        return this;
+    }
+
+    /// <summary>
+    /// Configures for a typical blog setup with www and naked domain.
+    /// </summary>
+    /// <param name="domain">The base domain (e.g., "myblog.com")</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public StaticSiteConstructPropsBuilder ForBlog(string domain)
+    {
+        _domainName = domain;
+        _siteSubDomain = "www";
+        _alternateDomains.Clear();
+        _alternateDomains.Add(domain); // Naked domain as alternate
+        return this;
+    }
+
+    /// <summary>
+    /// Configures for a documentation site setup.
+    /// </summary>
+    /// <param name="domain">The base domain</param>
+    /// <param name="apiDomain">Optional API domain for documentation API</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public StaticSiteConstructPropsBuilder ForDocumentation(string domain, string? apiDomain = null)
+    {
+        _domainName = domain;
+        _siteSubDomain = "docs";
+        _apiDomain = apiDomain;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures for a SPA (Single Page Application) with API integration.
+    /// </summary>
+    /// <param name="domain">The base domain</param>
+    /// <param name="apiDomain">The API domain for backend services</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public StaticSiteConstructPropsBuilder ForSinglePageApp(string domain, string apiDomain)
+    {
+        _domainName = domain;
+        _siteSubDomain = "app";
+        _apiDomain = apiDomain;
+        return this;
+    }
+
+    /// <summary>
+    /// Builds the StaticSiteConstructProps instance.
+    /// </summary>
+    /// <returns>The configured StaticSiteConstructProps</returns>
+    public StaticSiteConstructProps Build()
+    {
+        return new StaticSiteConstructProps
+        {
+            DomainName = _domainName,
+            SiteSubDomain = _siteSubDomain,
+            AssetPath = _assetPath,
+            ApiDomain = _apiDomain,
+            AlternateDomains = _alternateDomains.ToArray()
+        };
+    }
+}

--- a/src/LayeredCraft.Cdk.Constructs/Testing/StaticSiteConstructPropsBuilder.cs
+++ b/src/LayeredCraft.Cdk.Constructs/Testing/StaticSiteConstructPropsBuilder.cs
@@ -10,7 +10,7 @@ public class StaticSiteConstructPropsBuilder
 {
     private string _domainName = "example.com";
     private string _siteSubDomain = "www";
-    private string _assetPath = "./test-static-site";
+    private string _assetPath = CdkTestHelper.GetTestAssetPath("TestAssets/static-site");
     private string? _apiDomain = null;
     private readonly List<string> _alternateDomains = new();
 

--- a/test/LayeredCraft.Cdk.Constructs.Tests/Constructs/StaticSiteConstructTests.cs
+++ b/test/LayeredCraft.Cdk.Constructs.Tests/Constructs/StaticSiteConstructTests.cs
@@ -13,7 +13,7 @@ public class StaticSiteConstructTests
     public void Construct_ShouldCreateBasicStaticSite()
     {
         // Arrange
-        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var (_, stack) = CdkTestHelper.CreateTestStack();
         var props = CdkTestHelper.CreateStaticSitePropsBuilder()
             .WithDomainName("example.com")
             .WithSiteSubDomain("www")
@@ -23,7 +23,7 @@ public class StaticSiteConstructTests
             .Build();
 
         // Act
-        var construct = new StaticSiteConstruct(stack, "TestStaticSite", props);
+        _ = new StaticSiteConstruct(stack, "TestStaticSite", props);
         var template = Template.FromStack(stack);
 
         // Assert
@@ -35,10 +35,10 @@ public class StaticSiteConstructTests
     public void Construct_WithAutoFixtureData_ShouldCreateBasicStaticSite(StaticSiteConstructProps props)
     {
         // Arrange
-        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var (_, stack) = CdkTestHelper.CreateTestStack();
 
         // Act
-        var construct = new StaticSiteConstruct(stack, "TestStaticSite", props);
+        _ = new StaticSiteConstruct(stack, "TestStaticSite", props);
         var template = Template.FromStack(stack);
 
         // Assert
@@ -55,10 +55,10 @@ public class StaticSiteConstructTests
     public void Construct_WithApiDomain_ShouldCreateApiProxyBehavior(StaticSiteConstructProps props)
     {
         // Arrange
-        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var (_, stack) = CdkTestHelper.CreateTestStack();
 
         // Act
-        var construct = new StaticSiteConstruct(stack, "TestStaticSite", props);
+        _ = new StaticSiteConstruct(stack, "TestStaticSite", props);
         var template = Template.FromStack(stack);
 
         // Assert
@@ -72,10 +72,10 @@ public class StaticSiteConstructTests
     public void Construct_WithAlternateDomains_ShouldCreateMultipleRoute53Records(StaticSiteConstructProps props)
     {
         // Arrange
-        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var (_, stack) = CdkTestHelper.CreateTestStack();
 
         // Act
-        var construct = new StaticSiteConstruct(stack, "TestStaticSite", props);
+        _ = new StaticSiteConstruct(stack, "TestStaticSite", props);
         var template = Template.FromStack(stack);
 
         // Assert
@@ -88,14 +88,14 @@ public class StaticSiteConstructTests
     public void Construct_ForBlogScenario_ShouldCreateProperConfiguration()
     {
         // Arrange
-        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var (_, stack) = CdkTestHelper.CreateTestStack();
         var props = CdkTestHelper.CreateStaticSitePropsBuilder()
             .ForBlog("myblog.com")
             .WithAssetPath(CdkTestHelper.GetTestAssetPath("TestAssets/static-site"))
             .Build();
 
         // Act
-        var construct = new StaticSiteConstruct(stack, "BlogSite", props);
+        _ = new StaticSiteConstruct(stack, "BlogSite", props);
         var template = Template.FromStack(stack);
 
         // Assert
@@ -108,14 +108,14 @@ public class StaticSiteConstructTests
     public void Construct_ForDocumentationScenario_ShouldCreateDocsSubdomain()
     {
         // Arrange
-        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var (_, stack) = CdkTestHelper.CreateTestStack();
         var props = CdkTestHelper.CreateStaticSitePropsBuilder()
             .ForDocumentation("mycompany.com", "api.mycompany.com")
             .WithAssetPath(CdkTestHelper.GetTestAssetPath("TestAssets/static-site"))
             .Build();
 
         // Act
-        var construct = new StaticSiteConstruct(stack, "DocsSite", props);
+        _ = new StaticSiteConstruct(stack, "DocsSite", props);
         var template = Template.FromStack(stack);
 
         // Assert
@@ -127,14 +127,14 @@ public class StaticSiteConstructTests
     public void Construct_ForSinglePageAppScenario_ShouldCreateAppSubdomainWithApi()
     {
         // Arrange
-        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var (_, stack) = CdkTestHelper.CreateTestStack();
         var props = CdkTestHelper.CreateStaticSitePropsBuilder()
             .ForSinglePageApp("myapp.com", "api.myapp.com")
             .WithAssetPath(CdkTestHelper.GetTestAssetPath("TestAssets/static-site"))
             .Build();
 
         // Act
-        var construct = new StaticSiteConstruct(stack, "AppSite", props);
+        _ = new StaticSiteConstruct(stack, "AppSite", props);
         var template = Template.FromStack(stack);
 
         // Assert
@@ -146,7 +146,7 @@ public class StaticSiteConstructTests
     public void Construct_ShouldCreateS3BucketWithCorrectConfiguration()
     {
         // Arrange
-        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var (_, stack) = CdkTestHelper.CreateTestStack();
         var props = CdkTestHelper.CreateStaticSitePropsBuilder()
             .WithDomainName("test.com")
             .WithSiteSubDomain("www")
@@ -154,7 +154,7 @@ public class StaticSiteConstructTests
             .Build();
 
         // Act
-        var construct = new StaticSiteConstruct(stack, "TestSite", props);
+        _ = new StaticSiteConstruct(stack, "TestSite", props);
         var template = Template.FromStack(stack);
 
         // Assert
@@ -180,7 +180,7 @@ public class StaticSiteConstructTests
     public void Construct_ShouldCreateCloudFrontDistributionWithCorrectCaching()
     {
         // Arrange
-        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var (_, stack) = CdkTestHelper.CreateTestStack();
         var props = CdkTestHelper.CreateStaticSitePropsBuilder()
             .WithDomainName("test.com")
             .WithSiteSubDomain("www")
@@ -188,7 +188,7 @@ public class StaticSiteConstructTests
             .Build();
 
         // Act
-        var construct = new StaticSiteConstruct(stack, "TestSite", props);
+        _ = new StaticSiteConstruct(stack, "TestSite", props);
         var template = Template.FromStack(stack);
 
         // Assert
@@ -219,13 +219,13 @@ public class StaticSiteConstructTests
     public void Construct_ShouldCreateBucketDeploymentWithCorrectConfiguration()
     {
         // Arrange
-        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var (_, stack) = CdkTestHelper.CreateTestStack();
         var props = CdkTestHelper.CreateStaticSitePropsBuilder()
             .WithAssetPath(CdkTestHelper.GetTestAssetPath("TestAssets/static-site"))
             .Build();
 
         // Act
-        var construct = new StaticSiteConstruct(stack, "TestSite", props);
+        _ = new StaticSiteConstruct(stack, "TestSite", props);
         var template = Template.FromStack(stack);
 
         // Assert
@@ -240,13 +240,13 @@ public class StaticSiteConstructTests
     public void Construct_WithNullApiDomain_ShouldNotCreateApiProxyBehavior()
     {
         // Arrange
-        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var (_, stack) = CdkTestHelper.CreateTestStack();
         var props = CdkTestHelper.CreateStaticSitePropsBuilder()
             .WithoutApiDomain()
             .Build();
 
         // Act
-        var construct = new StaticSiteConstruct(stack, "TestSite", props);
+        _ = new StaticSiteConstruct(stack, "TestSite", props);
         var template = Template.FromStack(stack);
 
         // Assert
@@ -257,13 +257,13 @@ public class StaticSiteConstructTests
     public void Construct_ShouldCreateMinimalResources()
     {
         // Arrange
-        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var (_, stack) = CdkTestHelper.CreateTestStack();
         var props = CdkTestHelper.CreateStaticSitePropsBuilder()
             .WithoutApiDomain()
             .Build();
 
         // Act
-        var construct = new StaticSiteConstruct(stack, "TestSite", props);
+        _ = new StaticSiteConstruct(stack, "TestSite", props);
         var template = Template.FromStack(stack);
 
         // Assert - Test only basic resource creation without BucketDeployment
@@ -277,13 +277,13 @@ public class StaticSiteConstructTests
     public void Construct_WithEmptyApiDomain_ShouldNotCreateApiProxyBehavior()
     {
         // Arrange
-        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var (_, stack) = CdkTestHelper.CreateTestStack();
         var props = CdkTestHelper.CreateStaticSitePropsBuilder()
             .WithApiDomain("")
             .Build();
 
         // Act
-        var construct = new StaticSiteConstruct(stack, "TestSite", props);
+        _ = new StaticSiteConstruct(stack, "TestSite", props);
         var template = Template.FromStack(stack);
 
         // Assert
@@ -294,13 +294,13 @@ public class StaticSiteConstructTests
     public void Construct_WithWhitespaceApiDomain_ShouldNotCreateApiProxyBehavior()
     {
         // Arrange
-        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var (_, stack) = CdkTestHelper.CreateTestStack();
         var props = CdkTestHelper.CreateStaticSitePropsBuilder()
             .WithApiDomain("   ")
             .Build();
 
         // Act
-        var construct = new StaticSiteConstruct(stack, "TestSite", props);
+        _ = new StaticSiteConstruct(stack, "TestSite", props);
         var template = Template.FromStack(stack);
 
         // Assert
@@ -311,14 +311,14 @@ public class StaticSiteConstructTests
     public void Construct_WithSingleAlternateDomain_ShouldCreateTwoRoute53Records()
     {
         // Arrange
-        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var (_, stack) = CdkTestHelper.CreateTestStack();
         var props = CdkTestHelper.CreateStaticSitePropsBuilder()
             .WithAlternateDomain("alt.example.com")
             .WithAssetPath(CdkTestHelper.GetTestAssetPath("TestAssets/static-site"))
             .Build();
 
         // Act
-        var construct = new StaticSiteConstruct(stack, "TestSite", props);
+        _ = new StaticSiteConstruct(stack, "TestSite", props);
         var template = Template.FromStack(stack);
 
         // Assert
@@ -331,14 +331,14 @@ public class StaticSiteConstructTests
     public void Construct_WithMultipleAlternateDomains_ShouldCreateCorrectNumberOfRoute53Records()
     {
         // Arrange
-        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var (_, stack) = CdkTestHelper.CreateTestStack();
         var props = CdkTestHelper.CreateStaticSitePropsBuilder()
             .WithAlternateDomains("alt1.example.com", "alt2.example.com", "alt3.example.com")
             .WithAssetPath(CdkTestHelper.GetTestAssetPath("TestAssets/static-site"))
             .Build();
 
         // Act
-        var construct = new StaticSiteConstruct(stack, "TestSite", props);
+        _ = new StaticSiteConstruct(stack, "TestSite", props);
         var template = Template.FromStack(stack);
 
         // Assert
@@ -353,7 +353,7 @@ public class StaticSiteConstructTests
     public void Construct_WithoutAlternateDomains_ShouldClearExistingAlternates()
     {
         // Arrange
-        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var (_, stack) = CdkTestHelper.CreateTestStack();
         var props = CdkTestHelper.CreateStaticSitePropsBuilder()
             .WithAlternateDomains("temp1.example.com", "temp2.example.com")
             .WithoutAlternateDomains()
@@ -361,7 +361,7 @@ public class StaticSiteConstructTests
             .Build();
 
         // Act
-        var construct = new StaticSiteConstruct(stack, "TestSite", props);
+        _ = new StaticSiteConstruct(stack, "TestSite", props);
         var template = Template.FromStack(stack);
 
         // Assert

--- a/test/LayeredCraft.Cdk.Constructs.Tests/Constructs/StaticSiteConstructTests.cs
+++ b/test/LayeredCraft.Cdk.Constructs.Tests/Constructs/StaticSiteConstructTests.cs
@@ -1,0 +1,371 @@
+using Amazon.CDK.Assertions;
+using LayeredCraft.Cdk.Constructs.Constructs;
+using LayeredCraft.Cdk.Constructs.Models;
+using LayeredCraft.Cdk.Constructs.Testing;
+using LayeredCraft.Cdk.Constructs.Tests.TestKit.Attributes;
+
+namespace LayeredCraft.Cdk.Constructs.Tests.Constructs;
+
+[Collection("CDK Tests")]
+public class StaticSiteConstructTests
+{
+    [Fact]
+    public void Construct_ShouldCreateBasicStaticSite()
+    {
+        // Arrange
+        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var props = CdkTestHelper.CreateStaticSitePropsBuilder()
+            .WithDomainName("example.com")
+            .WithSiteSubDomain("www")
+            .WithAssetPath(CdkTestHelper.GetTestAssetPath("TestAssets/static-site"))
+            .WithoutApiDomain()
+            .WithoutAlternateDomains()
+            .Build();
+
+        // Act
+        var construct = new StaticSiteConstruct(stack, "TestStaticSite", props);
+        var template = Template.FromStack(stack);
+
+        // Assert
+        template.ShouldHaveCompleteStaticSite("www.example.com", "www.example.com", hasApiProxy: false, domainCount: 1);
+    }
+
+    [Theory]
+    [StaticSiteConstructAutoData(includeApiDomain: false, includeAlternateDomains: false)]
+    public void Construct_WithAutoFixtureData_ShouldCreateBasicStaticSite(StaticSiteConstructProps props)
+    {
+        // Arrange
+        var (app, stack) = CdkTestHelper.CreateTestStack();
+
+        // Act
+        var construct = new StaticSiteConstruct(stack, "TestStaticSite", props);
+        var template = Template.FromStack(stack);
+
+        // Assert
+        var expectedDomain = $"{props.SiteSubDomain}.{props.DomainName}";
+        template.ShouldHaveStaticWebsiteBucket(expectedDomain);
+        template.ShouldHaveCloudFrontDistribution(expectedDomain);
+        template.ShouldHaveSSLCertificate(expectedDomain);
+        template.ShouldHaveRoute53Records(expectedDomain);
+        template.ShouldNotHaveApiProxyBehavior();
+    }
+
+    [Theory]
+    [StaticSiteConstructAutoData(includeApiDomain: true, includeAlternateDomains: false)]
+    public void Construct_WithApiDomain_ShouldCreateApiProxyBehavior(StaticSiteConstructProps props)
+    {
+        // Arrange
+        var (app, stack) = CdkTestHelper.CreateTestStack();
+
+        // Act
+        var construct = new StaticSiteConstruct(stack, "TestStaticSite", props);
+        var template = Template.FromStack(stack);
+
+        // Assert
+        var expectedDomain = $"{props.SiteSubDomain}.{props.DomainName}";
+        template.ShouldHaveCompleteStaticSite(expectedDomain, expectedDomain, hasApiProxy: true, domainCount: 1);
+        template.ShouldHaveApiProxyBehavior(props.ApiDomain!);
+    }
+
+    [Theory]
+    [StaticSiteConstructAutoData(includeApiDomain: false, includeAlternateDomains: true)]
+    public void Construct_WithAlternateDomains_ShouldCreateMultipleRoute53Records(StaticSiteConstructProps props)
+    {
+        // Arrange
+        var (app, stack) = CdkTestHelper.CreateTestStack();
+
+        // Act
+        var construct = new StaticSiteConstruct(stack, "TestStaticSite", props);
+        var template = Template.FromStack(stack);
+
+        // Assert
+        var expectedDomain = $"{props.SiteSubDomain}.{props.DomainName}";
+        var expectedRecordCount = 1 + props.AlternateDomains.Length; // Primary + alternates
+        template.ShouldHaveCompleteStaticSite(expectedDomain, expectedDomain, hasApiProxy: false, domainCount: expectedRecordCount);
+    }
+
+    [Fact]
+    public void Construct_ForBlogScenario_ShouldCreateProperConfiguration()
+    {
+        // Arrange
+        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var props = CdkTestHelper.CreateStaticSitePropsBuilder()
+            .ForBlog("myblog.com")
+            .WithAssetPath(CdkTestHelper.GetTestAssetPath("TestAssets/static-site"))
+            .Build();
+
+        // Act
+        var construct = new StaticSiteConstruct(stack, "BlogSite", props);
+        var template = Template.FromStack(stack);
+
+        // Assert
+        template.ShouldHaveCompleteStaticSite("www.myblog.com", "www.myblog.com", hasApiProxy: false, domainCount: 2);
+        template.ShouldHaveRoute53Records("www.myblog.com");
+        template.ShouldHaveRoute53Records("myblog.com");
+    }
+
+    [Fact]
+    public void Construct_ForDocumentationScenario_ShouldCreateDocsSubdomain()
+    {
+        // Arrange
+        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var props = CdkTestHelper.CreateStaticSitePropsBuilder()
+            .ForDocumentation("mycompany.com", "api.mycompany.com")
+            .WithAssetPath(CdkTestHelper.GetTestAssetPath("TestAssets/static-site"))
+            .Build();
+
+        // Act
+        var construct = new StaticSiteConstruct(stack, "DocsSite", props);
+        var template = Template.FromStack(stack);
+
+        // Assert
+        template.ShouldHaveCompleteStaticSite("docs.mycompany.com", "docs.mycompany.com", hasApiProxy: true, domainCount: 1);
+        template.ShouldHaveApiProxyBehavior("api.mycompany.com");
+    }
+
+    [Fact]
+    public void Construct_ForSinglePageAppScenario_ShouldCreateAppSubdomainWithApi()
+    {
+        // Arrange
+        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var props = CdkTestHelper.CreateStaticSitePropsBuilder()
+            .ForSinglePageApp("myapp.com", "api.myapp.com")
+            .WithAssetPath(CdkTestHelper.GetTestAssetPath("TestAssets/static-site"))
+            .Build();
+
+        // Act
+        var construct = new StaticSiteConstruct(stack, "AppSite", props);
+        var template = Template.FromStack(stack);
+
+        // Assert
+        template.ShouldHaveCompleteStaticSite("app.myapp.com", "app.myapp.com", hasApiProxy: true, domainCount: 1);
+        template.ShouldHaveApiProxyBehavior("api.myapp.com");
+    }
+
+    [Fact]
+    public void Construct_ShouldCreateS3BucketWithCorrectConfiguration()
+    {
+        // Arrange
+        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var props = CdkTestHelper.CreateStaticSitePropsBuilder()
+            .WithDomainName("test.com")
+            .WithSiteSubDomain("www")
+            .WithAssetPath(CdkTestHelper.GetTestAssetPath("TestAssets/static-site"))
+            .Build();
+
+        // Act
+        var construct = new StaticSiteConstruct(stack, "TestSite", props);
+        var template = Template.FromStack(stack);
+
+        // Assert
+        template.HasResourceProperties("AWS::S3::Bucket", Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "BucketName", "www.test.com" },
+            { "WebsiteConfiguration", Match.ObjectLike(new Dictionary<string, object>
+            {
+                { "IndexDocument", "index.html" },
+                { "ErrorDocument", "index.html" }
+            }) },
+            { "PublicAccessBlockConfiguration", Match.ObjectLike(new Dictionary<string, object>
+            {
+                { "BlockPublicPolicy", false },
+                { "BlockPublicAcls", false },
+                { "IgnorePublicAcls", false },
+                { "RestrictPublicBuckets", false }
+            }) }
+        }));
+    }
+
+    [Fact]
+    public void Construct_ShouldCreateCloudFrontDistributionWithCorrectCaching()
+    {
+        // Arrange
+        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var props = CdkTestHelper.CreateStaticSitePropsBuilder()
+            .WithDomainName("test.com")
+            .WithSiteSubDomain("www")
+            .WithAssetPath(CdkTestHelper.GetTestAssetPath("TestAssets/static-site"))
+            .Build();
+
+        // Act
+        var construct = new StaticSiteConstruct(stack, "TestSite", props);
+        var template = Template.FromStack(stack);
+
+        // Assert
+        template.HasResourceProperties("AWS::CloudFront::Distribution", Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "DistributionConfig", Match.ObjectLike(new Dictionary<string, object>
+            {
+                { "Enabled", true },
+                { "Aliases", Match.ArrayWith(["www.test.com"]) },
+                { "DefaultCacheBehavior", Match.ObjectLike(new Dictionary<string, object>
+                {
+                    { "AllowedMethods", Match.ArrayWith(["GET", "HEAD"]) },
+                    { "Compress", true }
+                }) },
+                { "CustomErrorResponses", Match.ArrayWith([
+                    Match.ObjectLike(new Dictionary<string, object>
+                    {
+                        { "ErrorCode", 403 },
+                        { "ResponseCode", 200 },
+                        { "ResponsePagePath", "/index.html" }
+                    })
+                ]) }
+            }) }
+        }));
+    }
+
+    [Fact]
+    public void Construct_ShouldCreateBucketDeploymentWithCorrectConfiguration()
+    {
+        // Arrange
+        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var props = CdkTestHelper.CreateStaticSitePropsBuilder()
+            .WithAssetPath(CdkTestHelper.GetTestAssetPath("TestAssets/static-site"))
+            .Build();
+
+        // Act
+        var construct = new StaticSiteConstruct(stack, "TestSite", props);
+        var template = Template.FromStack(stack);
+
+        // Assert
+        template.ShouldHaveBucketDeployment();
+        template.HasResourceProperties("Custom::CDKBucketDeployment", Match.ObjectLike(new Dictionary<string, object>
+        {
+            { "DistributionPaths", Match.ArrayWith(["/*"]) }
+        }));
+    }
+
+    [Fact]
+    public void Construct_WithNullApiDomain_ShouldNotCreateApiProxyBehavior()
+    {
+        // Arrange
+        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var props = CdkTestHelper.CreateStaticSitePropsBuilder()
+            .WithoutApiDomain()
+            .Build();
+
+        // Act
+        var construct = new StaticSiteConstruct(stack, "TestSite", props);
+        var template = Template.FromStack(stack);
+
+        // Assert
+        template.ShouldNotHaveApiProxyBehavior();
+    }
+
+    [Fact]
+    public void Construct_ShouldCreateMinimalResources()
+    {
+        // Arrange
+        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var props = CdkTestHelper.CreateStaticSitePropsBuilder()
+            .WithoutApiDomain()
+            .Build();
+
+        // Act
+        var construct = new StaticSiteConstruct(stack, "TestSite", props);
+        var template = Template.FromStack(stack);
+
+        // Assert - Test only basic resource creation without BucketDeployment
+        template.ResourceCountIs("AWS::S3::Bucket", 1);
+        template.ResourceCountIs("AWS::CloudFront::Distribution", 1);
+        template.ResourceCountIs("AWS::CertificateManager::Certificate", 1);
+        template.ResourceCountIs("AWS::Route53::RecordSet", 1);
+    }
+
+    [Fact]
+    public void Construct_WithEmptyApiDomain_ShouldNotCreateApiProxyBehavior()
+    {
+        // Arrange
+        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var props = CdkTestHelper.CreateStaticSitePropsBuilder()
+            .WithApiDomain("")
+            .Build();
+
+        // Act
+        var construct = new StaticSiteConstruct(stack, "TestSite", props);
+        var template = Template.FromStack(stack);
+
+        // Assert
+        template.ShouldNotHaveApiProxyBehavior();
+    }
+
+    [Fact]
+    public void Construct_WithWhitespaceApiDomain_ShouldNotCreateApiProxyBehavior()
+    {
+        // Arrange
+        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var props = CdkTestHelper.CreateStaticSitePropsBuilder()
+            .WithApiDomain("   ")
+            .Build();
+
+        // Act
+        var construct = new StaticSiteConstruct(stack, "TestSite", props);
+        var template = Template.FromStack(stack);
+
+        // Assert
+        template.ShouldNotHaveApiProxyBehavior();
+    }
+
+    [Fact]
+    public void Construct_WithSingleAlternateDomain_ShouldCreateTwoRoute53Records()
+    {
+        // Arrange
+        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var props = CdkTestHelper.CreateStaticSitePropsBuilder()
+            .WithAlternateDomain("alt.example.com")
+            .WithAssetPath(CdkTestHelper.GetTestAssetPath("TestAssets/static-site"))
+            .Build();
+
+        // Act
+        var construct = new StaticSiteConstruct(stack, "TestSite", props);
+        var template = Template.FromStack(stack);
+
+        // Assert
+        template.ShouldHaveCompleteStaticSite("www.example.com", "www.example.com", hasApiProxy: false, domainCount: 2);
+        template.ShouldHaveRoute53Records("www.example.com");
+        template.ShouldHaveRoute53Records("alt.example.com");
+    }
+
+    [Fact]
+    public void Construct_WithMultipleAlternateDomains_ShouldCreateCorrectNumberOfRoute53Records()
+    {
+        // Arrange
+        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var props = CdkTestHelper.CreateStaticSitePropsBuilder()
+            .WithAlternateDomains("alt1.example.com", "alt2.example.com", "alt3.example.com")
+            .WithAssetPath(CdkTestHelper.GetTestAssetPath("TestAssets/static-site"))
+            .Build();
+
+        // Act
+        var construct = new StaticSiteConstruct(stack, "TestSite", props);
+        var template = Template.FromStack(stack);
+
+        // Assert
+        template.ShouldHaveCompleteStaticSite("www.example.com", "www.example.com", hasApiProxy: false, domainCount: 4);
+        template.ShouldHaveRoute53Records("www.example.com");
+        template.ShouldHaveRoute53Records("alt1.example.com");
+        template.ShouldHaveRoute53Records("alt2.example.com");
+        template.ShouldHaveRoute53Records("alt3.example.com");
+    }
+
+    [Fact]
+    public void Construct_WithoutAlternateDomains_ShouldClearExistingAlternates()
+    {
+        // Arrange
+        var (app, stack) = CdkTestHelper.CreateTestStack();
+        var props = CdkTestHelper.CreateStaticSitePropsBuilder()
+            .WithAlternateDomains("temp1.example.com", "temp2.example.com")
+            .WithoutAlternateDomains()
+            .WithAssetPath(CdkTestHelper.GetTestAssetPath("TestAssets/static-site"))
+            .Build();
+
+        // Act
+        var construct = new StaticSiteConstruct(stack, "TestSite", props);
+        var template = Template.FromStack(stack);
+
+        // Assert
+        template.ShouldHaveCompleteStaticSite("www.example.com", "www.example.com", hasApiProxy: false, domainCount: 1);
+        template.ShouldHaveRoute53Records("www.example.com");
+    }
+}

--- a/test/LayeredCraft.Cdk.Constructs.Tests/LayeredCraft.Cdk.Constructs.Tests.csproj
+++ b/test/LayeredCraft.Cdk.Constructs.Tests/LayeredCraft.Cdk.Constructs.Tests.csproj
@@ -47,6 +47,9 @@
         <None Include="TestAssets\test-lambda.zip">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Include="TestAssets\static-site\**\*">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
     </ItemGroup>
 
 </Project>

--- a/test/LayeredCraft.Cdk.Constructs.Tests/TestAssets/static-site/about.html
+++ b/test/LayeredCraft.Cdk.Constructs.Tests/TestAssets/static-site/about.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>About - Test Static Site</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <h1>About</h1>
+        <nav>
+            <ul>
+                <li><a href="/">Home</a></li>
+                <li><a href="/about.html">About</a></li>
+            </ul>
+        </nav>
+    </header>
+    
+    <main>
+        <section>
+            <h2>About This Test Site</h2>
+            <p>This is an about page for the test static website.</p>
+            <p>It demonstrates multi-page functionality and routing.</p>
+        </section>
+    </main>
+    
+    <footer>
+        <p>&copy; 2024 Test Static Site. All rights reserved.</p>
+    </footer>
+    
+    <script src="app.js"></script>
+</body>
+</html>

--- a/test/LayeredCraft.Cdk.Constructs.Tests/TestAssets/static-site/app.js
+++ b/test/LayeredCraft.Cdk.Constructs.Tests/TestAssets/static-site/app.js
@@ -1,0 +1,27 @@
+// Test Static Site JavaScript
+
+document.addEventListener('DOMContentLoaded', function() {
+    console.log('Test static site loaded successfully');
+    
+    // Add some basic interactivity for testing
+    const navLinks = document.querySelectorAll('nav a');
+    navLinks.forEach(link => {
+        link.addEventListener('click', function(e) {
+            console.log('Navigation link clicked:', this.href);
+        });
+    });
+    
+    // Test API functionality if available
+    if (window.location.pathname.includes('/api/')) {
+        console.log('API route detected');
+    }
+    
+    // Simple feature detection
+    const features = {
+        localStorage: typeof(Storage) !== "undefined",
+        fetch: typeof(fetch) !== "undefined",
+        webGL: !!window.WebGLRenderingContext
+    };
+    
+    console.log('Browser features:', features);
+});

--- a/test/LayeredCraft.Cdk.Constructs.Tests/TestAssets/static-site/index.html
+++ b/test/LayeredCraft.Cdk.Constructs.Tests/TestAssets/static-site/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test Static Site</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <h1>Test Static Site</h1>
+        <nav>
+            <ul>
+                <li><a href="/">Home</a></li>
+                <li><a href="/about.html">About</a></li>
+            </ul>
+        </nav>
+    </header>
+    
+    <main>
+        <section>
+            <h2>Welcome to the Test Site</h2>
+            <p>This is a test static website used for CDK construct testing.</p>
+            <p>It includes multiple pages and assets to verify proper deployment.</p>
+        </section>
+    </main>
+    
+    <footer>
+        <p>&copy; 2024 Test Static Site. All rights reserved.</p>
+    </footer>
+    
+    <script src="app.js"></script>
+</body>
+</html>

--- a/test/LayeredCraft.Cdk.Constructs.Tests/TestAssets/static-site/styles.css
+++ b/test/LayeredCraft.Cdk.Constructs.Tests/TestAssets/static-site/styles.css
@@ -1,0 +1,62 @@
+/* Test Static Site Styles */
+
+body {
+    font-family: Arial, sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+    color: #333;
+    background-color: #f4f4f4;
+}
+
+header {
+    background-color: #333;
+    color: white;
+    padding: 1rem 0;
+    text-align: center;
+}
+
+header h1 {
+    margin: 0;
+}
+
+nav ul {
+    list-style: none;
+    padding: 0;
+    margin: 1rem 0 0 0;
+}
+
+nav ul li {
+    display: inline;
+    margin: 0 10px;
+}
+
+nav ul li a {
+    color: white;
+    text-decoration: none;
+}
+
+nav ul li a:hover {
+    text-decoration: underline;
+}
+
+main {
+    max-width: 800px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+    background-color: white;
+    border-radius: 5px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}
+
+section {
+    padding: 2rem;
+}
+
+footer {
+    text-align: center;
+    padding: 1rem 0;
+    background-color: #333;
+    color: white;
+    margin-top: 2rem;
+}

--- a/test/LayeredCraft.Cdk.Constructs.Tests/TestKit/Attributes/StaticSiteConstructAutoDataAttribute.cs
+++ b/test/LayeredCraft.Cdk.Constructs.Tests/TestKit/Attributes/StaticSiteConstructAutoDataAttribute.cs
@@ -1,0 +1,18 @@
+using AutoFixture.Xunit3;
+using LayeredCraft.Cdk.Constructs.Tests.TestKit.Customizations;
+
+namespace LayeredCraft.Cdk.Constructs.Tests.TestKit.Attributes;
+
+/// <summary>
+/// AutoData attribute for StaticSiteConstruct tests with customizable configuration.
+/// </summary>
+public class StaticSiteConstructAutoDataAttribute(bool includeApiDomain = true, bool includeAlternateDomains = true) : AutoDataAttribute(() => CreateFixture(includeApiDomain, includeAlternateDomains))
+{
+    private static IFixture CreateFixture(bool includeApiDomain, bool includeAlternateDomains)
+    {
+        return BaseFixtureFactory.CreateFixture(fixture =>
+        {
+            fixture.Customize(new StaticSiteConstructCustomization(includeApiDomain, includeAlternateDomains));
+        });
+    }
+}

--- a/test/LayeredCraft.Cdk.Constructs.Tests/TestKit/Customizations/StaticSiteConstructCustomization.cs
+++ b/test/LayeredCraft.Cdk.Constructs.Tests/TestKit/Customizations/StaticSiteConstructCustomization.cs
@@ -1,0 +1,23 @@
+using LayeredCraft.Cdk.Constructs.Models;
+using LayeredCraft.Cdk.Constructs.Testing;
+
+namespace LayeredCraft.Cdk.Constructs.Tests.TestKit.Customizations;
+
+/// <summary>
+/// AutoFixture customization for StaticSiteConstructProps to provide realistic test data.
+/// </summary>
+public class StaticSiteConstructCustomization(bool includeApiDomain = true, bool includeAlternateDomains = true)
+    : ICustomization
+{
+    public void Customize(IFixture fixture)
+    {
+        fixture.Customize<StaticSiteConstructProps>(transform => transform
+            .With(props => props.DomainName, "example.com")
+            .With(props => props.SiteSubDomain, "www")
+            .With(props => props.AssetPath, CdkTestHelper.GetTestAssetPath("TestAssets/static-site"))
+            .With(props => props.ApiDomain, includeApiDomain ? "api.example.com" : null)
+            .With(props => props.AlternateDomains, includeAlternateDomains 
+                ? ["example.com", "alt.example.com"] 
+                : []));
+    }
+}

--- a/test/LayeredCraft.Cdk.Constructs.Tests/Testing/TestingHelpersTests.cs
+++ b/test/LayeredCraft.Cdk.Constructs.Tests/Testing/TestingHelpersTests.cs
@@ -804,6 +804,34 @@ public class TestingHelpersTests
         props.AssetPath.Should().Be(customPath);
         props.AssetPath.Should().EndWith("TestAssets/custom-site");
     }
+
+    [Fact]
+    public void PropsBuilder_ShouldConfigureSnapStart()
+    {
+        // Act
+        var props = CdkTestHelper.CreatePropsBuilder(AssetPathExtensions.GetTestLambdaZipPath())
+            .WithFunctionName("snapstart-test")
+            .WithSnapStart(true)
+            .Build();
+
+        // Assert
+        props.FunctionName.Should().Be("snapstart-test");
+        props.EnableSnapStart.Should().BeTrue();
+    }
+
+    [Fact]
+    public void PropsBuilder_ShouldDisableSnapStart()
+    {
+        // Act
+        var props = CdkTestHelper.CreatePropsBuilder(AssetPathExtensions.GetTestLambdaZipPath())
+            .WithFunctionName("no-snapstart-test")
+            .WithSnapStart(false)
+            .Build();
+
+        // Assert
+        props.FunctionName.Should().Be("no-snapstart-test");
+        props.EnableSnapStart.Should().BeFalse();
+    }
 }
 
 // Test helper interface for custom props testing

--- a/test/LayeredCraft.Cdk.Constructs.Tests/Testing/TestingHelpersTests.cs
+++ b/test/LayeredCraft.Cdk.Constructs.Tests/Testing/TestingHelpersTests.cs
@@ -1,8 +1,10 @@
 using Amazon.CDK.Assertions;
 using AwesomeAssertions;
 using LayeredCraft.Cdk.Constructs.Constructs;
+using LayeredCraft.Cdk.Constructs.Models;
 using LayeredCraft.Cdk.Constructs.Testing;
 using LayeredCraft.Cdk.Constructs.Tests.TestKit.Extensions;
+using LayeredCraft.Cdk.Constructs.Tests.TestKit.Customizations;
 
 namespace LayeredCraft.Cdk.Constructs.Tests.Testing;
 
@@ -668,6 +670,139 @@ public class TestingHelpersTests
         });
         
         stack.IsInternalConstructor.Should().BeTrue();
+    }
+
+    [Fact]
+    public void StaticSiteConstructCustomization_WithApiDomainIncluded_ShouldSetApiDomain()
+    {
+        // Arrange
+        var fixture = new Fixture();
+        var customization = new StaticSiteConstructCustomization(includeApiDomain: true, includeAlternateDomains: false);
+
+        // Act
+        customization.Customize(fixture);
+        var props = fixture.Create<StaticSiteConstructProps>();
+
+        // Assert
+        props.ApiDomain.Should().Be("api.example.com");
+        props.AlternateDomains.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void StaticSiteConstructCustomization_WithApiDomainExcluded_ShouldNotSetApiDomain()
+    {
+        // Arrange
+        var fixture = new Fixture();
+        var customization = new StaticSiteConstructCustomization(includeApiDomain: false, includeAlternateDomains: false);
+
+        // Act
+        customization.Customize(fixture);
+        var props = fixture.Create<StaticSiteConstructProps>();
+
+        // Assert
+        props.ApiDomain.Should().BeNull();
+        props.AlternateDomains.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void StaticSiteConstructCustomization_WithAlternateDomainsIncluded_ShouldSetAlternateDomains()
+    {
+        // Arrange
+        var fixture = new Fixture();
+        var customization = new StaticSiteConstructCustomization(includeApiDomain: false, includeAlternateDomains: true);
+
+        // Act
+        customization.Customize(fixture);
+        var props = fixture.Create<StaticSiteConstructProps>();
+
+        // Assert
+        props.ApiDomain.Should().BeNull();
+        props.AlternateDomains.Should().HaveCount(2);
+        props.AlternateDomains.Should().Contain("example.com");
+        props.AlternateDomains.Should().Contain("alt.example.com");
+    }
+
+    [Fact]
+    public void StaticSiteConstructCustomization_WithAlternateDomainsExcluded_ShouldNotSetAlternateDomains()
+    {
+        // Arrange
+        var fixture = new Fixture();
+        var customization = new StaticSiteConstructCustomization(includeApiDomain: false, includeAlternateDomains: false);
+
+        // Act
+        customization.Customize(fixture);
+        var props = fixture.Create<StaticSiteConstructProps>();
+
+        // Assert
+        props.ApiDomain.Should().BeNull();
+        props.AlternateDomains.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void StaticSiteConstructCustomization_WithBothIncluded_ShouldSetBothApiDomainAndAlternateDomains()
+    {
+        // Arrange
+        var fixture = new Fixture();
+        var customization = new StaticSiteConstructCustomization(includeApiDomain: true, includeAlternateDomains: true);
+
+        // Act
+        customization.Customize(fixture);
+        var props = fixture.Create<StaticSiteConstructProps>();
+
+        // Assert
+        props.ApiDomain.Should().Be("api.example.com");
+        props.AlternateDomains.Should().HaveCount(2);
+        props.AlternateDomains.Should().Contain("example.com");
+        props.AlternateDomains.Should().Contain("alt.example.com");
+    }
+
+    [Fact]
+    public void StaticSiteConstructCustomization_ShouldAlwaysSetRequiredProperties()
+    {
+        // Arrange
+        var fixture = new Fixture();
+        var customization = new StaticSiteConstructCustomization(includeApiDomain: false, includeAlternateDomains: false);
+
+        // Act
+        customization.Customize(fixture);
+        var props = fixture.Create<StaticSiteConstructProps>();
+
+        // Assert
+        props.DomainName.Should().Be("example.com");
+        props.SiteSubDomain.Should().Be("www");
+        props.AssetPath.Should().EndWith("TestAssets/static-site");
+        Path.IsPathRooted(props.AssetPath).Should().BeTrue("Asset path should be absolute");
+    }
+
+    [Fact]
+    public void CdkTestHelper_ShouldCreateStaticSitePropsBuilderWithDefaults()
+    {
+        // Act
+        var builder = CdkTestHelper.CreateStaticSitePropsBuilder();
+        var props = builder.Build();
+
+        // Assert
+        props.DomainName.Should().Be("example.com");
+        props.SiteSubDomain.Should().Be("www");
+        props.AssetPath.Should().EndWith("TestAssets/static-site");
+        Path.IsPathRooted(props.AssetPath).Should().BeTrue("Asset path should be absolute");
+        props.ApiDomain.Should().BeNull();
+        props.AlternateDomains.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CdkTestHelper_ShouldCreateStaticSitePropsBuilderWithCustomAssetPath()
+    {
+        // Arrange
+        var customPath = CdkTestHelper.GetTestAssetPath("TestAssets/custom-site");
+
+        // Act
+        var builder = CdkTestHelper.CreateStaticSitePropsBuilder(customPath);
+        var props = builder.Build();
+
+        // Assert
+        props.AssetPath.Should().Be(customPath);
+        props.AssetPath.Should().EndWith("TestAssets/custom-site");
     }
 }
 


### PR DESCRIPTION
## Summary
• Add StaticSiteConstruct with S3, CloudFront, SSL, Route53, and asset deployment
• Support optional API proxying through CloudFront behaviors for /api/* paths  
• Include alternate domain configuration for multi-domain sites
• Add comprehensive testing infrastructure with AutoFixture and CDK assertions
• Include fluent builders for common scenarios (blog, docs, SPA)
• Add XML documentation for all public APIs
• Update README.md and CLAUDE.md with complete documentation and examples

## Test Plan
- [x] Add missing unit tests for WithAlternateDomain and WithAlternateDomains methods
- [x] Verify all existing tests pass with new StaticSiteConstruct
- [x] Test AutoFixture customizations for realistic test data
- [x] Verify CDK assertion helpers work correctly with generated CloudFormation templates
- [x] Test scenario-based builders (ForBlog, ForDocumentation, ForSinglePageApp)
- [x] Verify asset path resolution and test asset management
- [x] Test both API proxy enabled and disabled scenarios
- [x] Test multiple alternate domain configurations

🤖 Generated with [Claude Code](https://claude.ai/code)