### PR TITLE
Fix GitHub Pages configuration for architect theme

### DIFF
--- a/LayeredCraft.Cdk.Constructs.sln
+++ b/LayeredCraft.Cdk.Constructs.sln
@@ -27,6 +27,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{B4C8E2F1-3
 	ProjectSection(SolutionItems) = preProject
 		docs\_config.yml = docs\_config.yml
 		docs\index.md = docs\index.md
+		docs\assets\css\style.scss = docs\assets\css\style.scss
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "constructs", "constructs", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,21 +3,17 @@ description: Reusable AWS CDK constructs for .NET serverless applications
 baseurl: "/cdk-constructs"
 url: "https://layeredcraft.github.io"
 
+# Theme settings
+show_downloads: true
+google_analytics: # Add your tracking ID if needed
+
 # Build settings
 markdown: kramdown
-theme: architect
+remote_theme: pages-themes/architect@v0.2.0
 plugins:
   - jekyll-feed
   - jekyll-sitemap
-
-# Navigation
-header_pages:
-  - index.md
-  - constructs/lambda-function.md
-  - constructs/static-site.md
-  - constructs/dynamodb-table.md
-  - testing/index.md
-  - examples/index.md
+  - jekyll-remote-theme
 
 # GitHub repository
 github_username: LayeredCraft
@@ -35,15 +31,3 @@ exclude:
   - vendor/cache/
   - vendor/gems/
   - vendor/ruby/
-
-# Collections
-collections:
-  constructs:
-    output: true
-    permalink: /:collection/:name/
-  testing:
-    output: true
-    permalink: /:collection/:name/
-  examples:
-    output: true
-    permalink: /:collection/:name/

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1,0 +1,100 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+/* Custom styles for LayeredCraft CDK Constructs documentation */
+
+/* Improve code block styling */
+pre {
+  border-radius: 6px;
+  border: 1px solid #e1e4e8;
+}
+
+/* Better table styling */
+table {
+  border-collapse: collapse;
+  margin: 1em 0;
+  width: 100%;
+}
+
+table th,
+table td {
+  border: 1px solid #e1e4e8;
+  padding: 8px 12px;
+  text-align: left;
+}
+
+table th {
+  background-color: #f6f8fa;
+  font-weight: 600;
+}
+
+/* Improve navigation styling */
+.header-nav {
+  margin-top: 1em;
+}
+
+.header-nav a {
+  margin-right: 1em;
+  color: #fff;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.header-nav a:hover {
+  text-decoration: underline;
+}
+
+/* Badge styling for version, build status, etc. */
+.badges {
+  margin: 1em 0;
+}
+
+.badges img {
+  margin-right: 0.5em;
+}
+
+/* Better spacing for documentation sections */
+.main-content h2 {
+  margin-top: 2em;
+  margin-bottom: 1em;
+  border-bottom: 1px solid #e1e4e8;
+  padding-bottom: 0.5em;
+}
+
+.main-content h3 {
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+}
+
+/* Improve blockquote styling */
+blockquote {
+  border-left: 4px solid #0366d6;
+  padding-left: 1em;
+  margin-left: 0;
+  color: #6a737d;
+}
+
+/* Custom alert boxes */
+.alert {
+  padding: 1em;
+  margin: 1em 0;
+  border-radius: 6px;
+  border-left: 4px solid;
+}
+
+.alert-info {
+  background-color: #f0f8ff;
+  border-left-color: #0366d6;
+}
+
+.alert-warning {
+  background-color: #fffbf0;
+  border-left-color: #f9c513;
+}
+
+.alert-success {
+  background-color: #f0fff4;
+  border-left-color: #28a745;
+}


### PR DESCRIPTION
## Problem
GitHub Pages build was failing due to incorrect theme configuration. The `theme: architect` format doesn't work with GitHub Pages - it requires the `remote_theme` format.

## Solution
Updated the Jekyll configuration to use the proper GitHub Pages theme format and enhanced the styling.

### GitHub Pages Theme Fix
- ✅ Change from `theme: architect` to `remote_theme: pages-themes/architect@v0.2.0`
- ✅ Add `jekyll-remote-theme` plugin for proper theme loading
- ✅ Follow official GitHub Pages theme documentation

### Enhanced Theme Configuration
- ✅ Add `show_downloads: true` to enable GitHub repository download links
- ✅ Add `google_analytics` placeholder for future analytics setup
- ✅ Clean up unnecessary navigation and collections configuration
- ✅ Streamline Jekyll configuration for better performance

### Custom Styling
- ✅ Create `docs/assets/css/style.scss` with custom styles
- ✅ Improve code blocks, tables, and navigation styling
- ✅ Add custom alert boxes and better typography
- ✅ Enhance documentation-specific appearance

### Solution Structure
- ✅ Add new CSS file to Visual Studio solution for easy editing
- ✅ Maintain organized documentation structure in IDE

## Test Plan
- [ ] Verify GitHub Pages builds successfully after merge
- [ ] Check that architect theme is properly applied
- [ ] Confirm custom styling works correctly
- [ ] Test documentation site at https://layeredcraft.github.io/cdk-constructs/

## Expected Outcome
- GitHub Pages will build successfully with the architect theme
- Documentation will have a professional, technical appearance
- Custom styling will enhance readability and navigation
- Repository download links will be available in the theme header

## References
- [GitHub Pages Architect Theme Documentation](https://github.com/pages-themes/architect)
- [Jekyll Remote Theme Plugin](https://github.com/benbalter/jekyll-remote-theme)

🤖 Generated with [Claude Code](https://claude.ai/code)