### PR TITLE
Update Amazon.CDK.Lib to 2.204.0

### DIFF
--- a/src/LayeredCraft.Cdk.Constructs/LayeredCraft.Cdk.Constructs.csproj
+++ b/src/LayeredCraft.Cdk.Constructs/LayeredCraft.Cdk.Constructs.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Amazon.CDK.Lib" Version="2.203.1" />
+      <PackageReference Include="Amazon.CDK.Lib" Version="2.204.0" />
     </ItemGroup>
     <ItemGroup>
         <None Include="..\..\icon.png" Pack="true" PackagePath="" Visible="False" />


### PR DESCRIPTION
## Summary
- Update Amazon.CDK.Lib dependency from version 2.203.1 to 2.204.0
- Ensures compatibility with latest AWS CDK features and bug fixes

## Changes
- Updated `LayeredCraft.Cdk.Constructs.csproj` with new CDK library version

## Test Plan
- [ ] Build solution successfully
- [ ] Run all unit tests to ensure no breaking changes
- [ ] Verify all CDK constructs still function correctly
- [ ] Test example deployments if possible

🤖 Generated with [Claude Code](https://claude.ai/code)