### PR TITLE
docs: Complete v2.0.0 release documentation and version finalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,99 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2025-08-06
+
+### ⚠️ BREAKING CHANGES
+
+**OpenTelemetry Layer Configuration:**
+- **OpenTelemetry layer is now disabled by default** (was enabled by default in v1.x)
+- Added new required interface properties: `Architecture` and `OtelLayerVersion` 
+
+### ✨ Added
+
+- **Configurable OTEL layer architecture**: Support for both `amd64` and `arm64` architectures via `Architecture` property (default: "amd64")
+- **Configurable OTEL layer version**: Control OTEL layer version via `OtelLayerVersion` property (default: "0-117-0")
+- **Dynamic OTEL layer ARN format**: Now uses configurable architecture and version: `arn:aws:lambda:{region}:901920570463:layer:aws-otel-collector-{architecture}-ver-{version}:1`
+- **Testing helpers**: New builder methods `WithOtelLayerVersion()` and `WithArchitecture()` for test configuration
+
+### 🔄 Changed
+
+- **`IncludeOtelLayer` default**: Changed from `true` to `false` **(BREAKING CHANGE)**
+- **Updated OTEL layer version**: Now defaults to latest version (0-117-0, was 0-102-1)
+- **Updated AWS CDK dependency**: Upgraded to v2.209.1 from v2.206.0
+- **Test defaults**: All test attributes and customizations now default to OTEL disabled
+
+### 🐛 Fixed
+
+- **Future-proof OTEL versioning**: No longer requires package updates when AWS releases new OTEL layer versions
+
+### 📖 Migration Guide
+
+#### For users upgrading from v1.x who want to maintain OTEL functionality:
+
+**Before (v1.x - OTEL enabled by default):**
+```csharp
+var lambda = new LambdaFunctionConstruct(this, "MyLambda", new LambdaFunctionConstructProps
+{
+    FunctionName = "my-api",
+    FunctionSuffix = "prod",
+    AssetPath = "./lambda.zip",
+    RoleName = "my-api-role",
+    PolicyName = "my-api-policy"
+    // OTEL was enabled by default
+});
+```
+
+**After (v2.0+ - OTEL must be explicitly enabled):**
+```csharp
+var lambda = new LambdaFunctionConstruct(this, "MyLambda", new LambdaFunctionConstructProps
+{
+    FunctionName = "my-api",
+    FunctionSuffix = "prod",
+    AssetPath = "./lambda.zip",
+    RoleName = "my-api-role",
+    PolicyName = "my-api-policy",
+    IncludeOtelLayer = true,           // Must be explicitly enabled
+    Architecture = "amd64",            // Optional: specify architecture (default: amd64)
+    OtelLayerVersion = "0-117-0"       // Optional: specify version (default: latest)
+});
+```
+
+#### Benefits of the new approach:
+
+1. **Cost Control**: OTEL layer is now opt-in, preventing unexpected observability costs
+2. **Architecture Flexibility**: Support for both x86_64 (amd64) and ARM64 architectures
+3. **Version Control**: Specify exact OTEL layer versions for consistent deployments
+4. **Future Proof**: No more package updates needed when AWS releases new OTEL versions
+
+#### Testing Updates:
+
+**Before:**
+```csharp
+[LambdaFunctionConstructAutoData] // OTEL enabled by default
+public void Test_Lambda_With_OTEL(LambdaFunctionConstructProps props)
+```
+
+**After:**
+```csharp
+[LambdaFunctionConstructAutoData(includeOtelLayer: true)] // Must explicitly enable
+public void Test_Lambda_With_OTEL(LambdaFunctionConstructProps props)
+```
+
+## [1.0.1] - Previous Release
+
+### 🔄 Changed
+- Package dependency updates
+- Documentation improvements
+
+---
+
+## Support
+
+- **Issues**: [GitHub Issues](https://github.com/LayeredCraft/cdk-constructs/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/LayeredCraft/cdk-constructs/discussions)
+- **Documentation**: [https://layeredcraft.github.io/cdk-constructs/](https://layeredcraft.github.io/cdk-constructs/)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>2.0.0-beta</VersionPrefix>
+        <VersionPrefix>2.0.0</VersionPrefix>
         <!-- SPDX license identifier for MIT -->
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ A comprehensive library of reusable AWS CDK constructs for .NET projects, design
 
 ## Key Features
 
-- **🚀 Lambda Functions**: Comprehensive Lambda construct with OpenTelemetry support, IAM management, and environment configuration
+- **🚀 Lambda Functions**: Comprehensive Lambda construct with configurable OpenTelemetry support, IAM management, and environment configuration
 - **🌐 Static Sites**: Complete static website hosting with S3, CloudFront, SSL certificates, and Route53 DNS management
 - **📊 DynamoDB Tables**: Full-featured DynamoDB construct with streams, TTL, and global secondary indexes
 - **🧪 Testing Helpers**: Extensive testing utilities with fluent assertions and builders
@@ -43,6 +43,7 @@ public class MyStack : Stack
             AssetPath = "./lambda-deployment.zip",
             RoleName = "my-api-role",
             PolicyName = "my-api-policy",
+            IncludeOtelLayer = true, // Enable OpenTelemetry (disabled by default in v2.0+)
             GenerateUrl = true // Creates a Function URL for HTTP access
         });
 
@@ -63,7 +64,7 @@ public class MyStack : Stack
 
 Full-featured Lambda functions with:
 
-- OpenTelemetry integration
+- Configurable OpenTelemetry integration
 - IAM roles and policies
 - Environment variables
 - Function URLs

--- a/docs/testing/index.md
+++ b/docs/testing/index.md
@@ -109,10 +109,29 @@ var props = CdkTestHelper.CreatePropsBuilder(AssetPathExtensions.GetTestLambdaZi
     .WithS3Access("my-bucket")
     .WithApiGatewayPermission("arn:aws:execute-api:us-east-1:123456789012:abcdef123/*")
     .WithOtelEnabled(true)
+    .WithOtelLayerVersion("0-117-0")
+    .WithArchitecture("arm64")
     .WithSnapStart(true)
     .WithGenerateUrl(true)
     .Build();
 ```
+
+### OpenTelemetry Configuration (v2.0+)
+
+The props builder includes new methods for configuring OpenTelemetry settings:
+
+```csharp
+var props = CdkTestHelper.CreatePropsBuilder(AssetPathExtensions.GetTestLambdaZipPath())
+    .WithOtelEnabled(true)                    // Enable OTEL layer (disabled by default in v2.0+)
+    .WithOtelLayerVersion("0-117-0")         // Specify OTEL layer version
+    .WithArchitecture("arm64")               // Specify architecture (default: amd64)
+    .Build();
+```
+
+**Available OTEL methods:**
+- `WithOtelEnabled(bool)` - Enable/disable OpenTelemetry layer
+- `WithOtelLayerVersion(string)` - Specify OTEL layer version (e.g., "0-117-0")  
+- `WithArchitecture(string)` - Specify Lambda architecture ("amd64" or "arm64")
 
 ### Assertion Methods
 
@@ -239,10 +258,10 @@ public void Should_Create_Lambda_With_Custom_Settings(LambdaFunctionConstructPro
 
 ```csharp
 [Theory]
-[InlineData(true, true)]   // OTEL enabled, permissions included
-[InlineData(true, false)]  // OTEL enabled, no permissions
-[InlineData(false, true)]  // OTEL disabled, permissions included
-[InlineData(false, false)] // OTEL disabled, no permissions
+[InlineData(true, true)]   // OTEL explicitly enabled, permissions included
+[InlineData(true, false)]  // OTEL explicitly enabled, no permissions  
+[InlineData(false, true)]  // OTEL disabled (default in v2.0+), permissions included
+[InlineData(false, false)] // OTEL disabled (default in v2.0+), no permissions
 public void Should_Handle_Different_Configurations(bool includeOtel, bool includePermissions)
 {
     var props = CdkTestHelper.CreatePropsBuilder(AssetPathExtensions.GetTestLambdaZipPath())


### PR DESCRIPTION
## Summary
- Finalize version 2.0.0 (remove -beta suffix) 
- Add comprehensive CHANGELOG.md with breaking changes documentation
- Update all documentation to reflect OTEL layer configuration changes in v2.0.0

## Version Changes
- **Directory.Build.props**: `2.0.0-beta` → `2.0.0` (ready for stable release)

## New Documentation
- **CHANGELOG.md**: Complete v2.0.0 release notes with:
  - Breaking changes documentation
  - Migration guide from v1.x
  - New features and configuration options
  - Code examples for all new properties

## Documentation Updates

### docs/index.md
- Update feature descriptions to mention "configurable" OTEL support
- Add explicit `IncludeOtelLayer = true` to Quick Start example
- Clearly communicate the breaking change in default behavior

### docs/testing/index.md  
- Document new testing methods: `WithOtelLayerVersion()`, `WithArchitecture()`
- Update test scenario comments to reflect new OTEL defaults
- Add comprehensive "OpenTelemetry Configuration (v2.0+)" section
- Show proper testing patterns for the new properties

### docs/examples/index.md
- Add explicit OTEL enablement to production examples
- Create comprehensive "OpenTelemetry Configuration Examples" section with:
  - Basic OTEL enablement patterns
  - ARM64 architecture usage
  - Different OTEL layer versions
  - Migration from v1.x examples
  - Environment-specific configuration patterns
- Update environment configuration example to show new architecture support

## Key Breaking Change Communication
All documentation now clearly shows that:
- OTEL layer is **disabled by default** in v2.0+ (was enabled in v1.x)
- Users must explicitly set `IncludeOtelLayer = true` to enable OTEL
- New configurable properties: `Architecture` and `OtelLayerVersion`

## Benefits for Users
- **Clear migration path**: Step-by-step examples for upgrading from v1.x
- **Complete examples**: Real-world usage patterns for all new features
- **Testing guidance**: How to test with the new OTEL configuration
- **Professional release management**: Proper CHANGELOG and version management

## Related PRs
- Builds on #26 (configurable OTEL layer implementation)

🤖 Generated with [Claude Code](https://claude.ai/code)