### PR TITLE
feat: add SiteDomain property to StaticSiteConstruct and update dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ dotnet add test/LayeredCraft.Cdk.Constructs.Tests/ package PackageName
 - Configures Route53 DNS records for primary domain and alternates
 - Supports optional API proxying via CloudFront behaviors for `/api/*` paths
 - Includes automatic asset deployment with cache invalidation
+- Exposes `SiteDomain` property containing the fully qualified domain name
 
 **DynamoDbTableConstruct** (`src/LayeredCraft.Cdk.Constructs/DynamoDbTableConstruct.cs`)
 - Comprehensive CDK construct for DynamoDB table creation and configuration
@@ -88,7 +89,7 @@ dotnet add test/LayeredCraft.Cdk.Constructs.Tests/ package PackageName
 
 ### Target Frameworks
 - .NET 8.0 and .NET 9.0
-- Uses AWS CDK v2 (Amazon.CDK.Lib 2.203.1)
+- Uses AWS CDK v2 (Amazon.CDK.Lib 2.213.0)
 
 ### OpenTelemetry Configuration (v2.0.0+)
 Starting with version 2.0.0, the OpenTelemetry layer configuration has been updated:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>2.0.0</VersionPrefix>
+        <VersionPrefix>2.0.1</VersionPrefix>
         <!-- SPDX license identifier for MIT -->
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
 

--- a/docs/constructs/static-site.md
+++ b/docs/constructs/static-site.md
@@ -51,6 +51,29 @@ public class MyStack : Stack
 | `ApiDomain` | `string?` | `null` | API domain for proxy behavior |
 | `AlternateDomains` | `string[]` | `[]` | Additional domains to include in certificate |
 
+## Construct Properties
+
+The `StaticSiteConstruct` exposes the following properties after instantiation:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `SiteDomain` | `string` | Fully qualified domain name of the site (e.g., "www.example.com") |
+
+### Accessing Site Domain
+
+```csharp
+var site = new StaticSiteConstruct(this, "MySite", new StaticSiteConstructProps
+{
+    SiteBucketName = "my-website-bucket",
+    DomainName = "example.com",
+    SiteSubDomain = "www",
+    AssetPath = "./website-build"
+});
+
+// Access the computed site domain
+var domain = site.SiteDomain; // "www.example.com"
+```
+
 ## Advanced Examples
 
 ### Website with Subdomain

--- a/src/LayeredCraft.Cdk.Constructs/LayeredCraft.Cdk.Constructs.csproj
+++ b/src/LayeredCraft.Cdk.Constructs/LayeredCraft.Cdk.Constructs.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Amazon.CDK.Lib" Version="2.209.1" />
+      <PackageReference Include="Amazon.CDK.Lib" Version="2.213.0" />
     </ItemGroup>
     <ItemGroup>
         <None Include="..\..\docs\assets\icon.png" Pack="true" PackagePath="" Visible="False" />

--- a/test/LayeredCraft.Cdk.Constructs.Tests/LayeredCraft.Cdk.Constructs.Tests.csproj
+++ b/test/LayeredCraft.Cdk.Constructs.Tests/LayeredCraft.Cdk.Constructs.Tests.csproj
@@ -36,8 +36,8 @@
         <PackageReference Include="AwesomeAssertions" Version="9.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
         <PackageReference Include="NSubstitute" Version="5.3.0"/>
-        <PackageReference Include="xunit.v3" Version="3.0.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+        <PackageReference Include="xunit.v3" Version="3.0.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
## Summary

This PR introduces a new `SiteDomain` property to the `StaticSiteConstruct` and includes routine dependency updates for version 2.0.1.

- **New Feature**: Added public `SiteDomain` property to expose the fully qualified domain name after construct instantiation
- **Dependency Updates**: Updated AWS CDK from 2.209.1 to 2.213.0 and xUnit test dependencies
- **Documentation**: Added comprehensive XML documentation and updated all relevant documentation files
- **Version Bump**: Incremented version to 2.0.1

## Changes Made

### Core Functionality
- Added `SiteDomain` property to `StaticSiteConstruct` class with full XML documentation
- Refactored internal domain name usage to use the new public property

### Dependencies
- AWS CDK: `2.209.1` → `2.213.0`
- xUnit v3: `3.0.0` → `3.0.1`  
- xUnit runner: `3.1.3` → `3.1.4`

### Documentation
- Updated `CLAUDE.md` with new property information and CDK version
- Enhanced `docs/constructs/static-site.md` with property documentation and usage examples
- Added comprehensive XML documentation for the new property

## API Impact

This is a **non-breaking change** that only adds new functionality. Existing code will continue to work unchanged, but consumers can now access the computed site domain:

```csharp
var site = new StaticSiteConstruct(this, "MySite", props);
var domain = site.SiteDomain; // "www.example.com"
```

## Test Plan

- [x] Build solution successfully
- [x] All existing tests pass
- [x] Documentation updated and reviewed
- [x] XML documentation added for new property
- [x] No breaking changes to existing API

🤖 Generated with [Claude Code](https://claude.ai/code)