### PR TITLE
feat(cognito): add MfaSecondFactor support to CognitoUserPoolConstruct

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>2.2.0</VersionPrefix>
+        <VersionPrefix>2.3.0</VersionPrefix>
         <!-- SPDX license identifier for MIT -->
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
 

--- a/src/LayeredCraft.Cdk.Constructs/CognitoUserPoolConstruct.cs
+++ b/src/LayeredCraft.Cdk.Constructs/CognitoUserPoolConstruct.cs
@@ -59,6 +59,7 @@ public sealed class CognitoUserPoolConstruct : Construct
             },
             AccountRecovery = AccountRecovery.EMAIL_ONLY,
             Mfa = props.Mfa,
+            MfaSecondFactor = props.MfaSecondFactor,
             RemovalPolicy = props.RemovalPolicy,
         });
 

--- a/src/LayeredCraft.Cdk.Constructs/Models/CognitoUserPoolConstructProps.cs
+++ b/src/LayeredCraft.Cdk.Constructs/Models/CognitoUserPoolConstructProps.cs
@@ -13,6 +13,8 @@ public interface ICognitoUserPoolConstructProps
 
     Mfa Mfa { get; }
 
+    MfaSecondFactor? MfaSecondFactor { get; }
+
     int PasswordMinLength { get; }
     
     IReadOnlyList<ICognitoResourceServerProps> ResourceServers { get; }
@@ -30,6 +32,8 @@ public sealed record CognitoUserPoolConstructProps : ICognitoUserPoolConstructPr
     public RemovalPolicy RemovalPolicy { get; init; } = RemovalPolicy.DESTROY;
 
     public Mfa Mfa { get; init; } = Mfa.OFF;
+
+    public MfaSecondFactor? MfaSecondFactor { get; init; }
 
     public int PasswordMinLength { get; init; } = 12;
     public IReadOnlyList<ICognitoResourceServerProps> ResourceServers { get; init; } = [];


### PR DESCRIPTION
## Summary

Adds `MfaSecondFactor` as an optional property on `ICognitoUserPoolConstructProps` and `CognitoUserPoolConstructProps`. When set, it is passed directly to the CDK `UserPoolProps`, allowing callers to enable TOTP (`Otp = true`) or SMS (`Sms = true`) as a second authentication factor alongside the existing `Mfa` setting. Bumps the package version to `2.3.0`.

## Changes

- `CognitoUserPoolConstructProps` — added nullable `MfaSecondFactor? MfaSecondFactor` to both the interface and the concrete record (defaults to `null`, fully backward compatible)
- `CognitoUserPoolConstruct` — wires `props.MfaSecondFactor` through to `UserPoolProps.MfaSecondFactor`
- `Directory.Build.props` — version bumped from `2.2.0` to `2.3.0`

## Validation

- Existing tests pass without modification — the new property is nullable and existing test builders do not set it
- Manually verified via local package consumption in the `cipollina-infrastructure` stack with `Mfa = Mfa.REQUIRED` and `MfaSecondFactor = new MfaSecondFactor { Otp = true, Sms = false }`

## Notes for Reviewers

Adding a property to the `ICognitoUserPoolConstructProps` interface is technically a breaking change for external implementors, though in practice all consumers use the concrete `CognitoUserPoolConstructProps` record. Treated as a minor bump accordingly.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)