### PR TITLE
ci: upgrade devops-templates to v10.0 with NuGet trusted publishing

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -7,7 +7,7 @@ on:
 permissions: write-all
 jobs:
   build:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v8.1
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v10.0
     with:
       solution: LayeredCraft.Cdk.Constructs.slnx
       hasTests: true

--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   validate:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v8.1
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v10.0

--- a/.github/workflows/publish-preview.yaml
+++ b/.github/workflows/publish-preview.yaml
@@ -12,14 +12,16 @@ on:
       - 'mkdocs.yml'
       - 'requirements.txt'
 
-permissions: write-all
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   # To add support for additional .NET versions (e.g. net9, net11), add release branches
   # (e.g. release/net9) and wire up separate caller workflows targeting those branches.
 
-  publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v8.1
+  build:
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v10.0
     with:
       solution: LayeredCraft.Cdk.Constructs.slnx
       dotnetVersion:  |
@@ -30,3 +32,14 @@ jobs:
       prereleaseIdentifier: alpha
       hasTests: true
     secrets: inherit
+
+  push:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: LayeredCraft/devops-templates/.github/actions/nuget-push@v10.0
+        with:
+          nuget_user: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -4,14 +4,15 @@ on:
   release:
     types: [published]
 
-permissions: write-all
+permissions:
+  contents: write
 
 jobs:
   # To add support for additional .NET versions (e.g. net9, net11), add release branches
   # (e.g. release/net9) and wire up separate caller workflows targeting those branches.
 
-  publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v8.1
+  build:
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v10.0
     with:
       solution: LayeredCraft.Cdk.Constructs.slnx
       dotnetVersion:  |
@@ -21,3 +22,14 @@ jobs:
         11.0.x
       hasTests: true
     secrets: inherit
+
+  push:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: LayeredCraft/devops-templates/.github/actions/nuget-push@v10.0
+        with:
+          nuget_user: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   draft:
-    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v8.1
+    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v10.0
     with:
       event_name: ${{ github.event_name }}
       pr_draft: ${{ github.event.pull_request.draft == true }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,18 +3,18 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup Label="Build">
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
   </ItemGroup>
   <ItemGroup Label="AWS">
-    <PackageVersion Include="Amazon.CDK.Lib" Version="2.250.0" />
+    <PackageVersion Include="Amazon.CDK.Lib" Version="2.260.0" />
   </ItemGroup>
   <ItemGroup Label="Testing">
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0" />
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
## Summary

Upgrades all `devops-templates` references from `v8.1` to `v10.0` and converts the publish flows to use NuGet Trusted Publishing (OIDC) via the `nuget-push` composite action. Also includes pending package updates from `Directory.Packages.props`.

## Changes

**`publish-preview.yaml` and `publish-release.yaml`** — structural change
- Renamed `publish` job to `build`; shared template now handles build/test/pack/artifact upload only
- Added `push` job using `nuget-push@v10.0` composite action for OIDC login and NuGet push
- Tightened `permissions: write-all` to least-privilege per job

**`pr-build.yaml`, `pr-title-check.yaml`, `release-drafter.yaml`** — version bump only
- `@v8.1` → `@v10.0`, no other changes

**`Directory.Packages.props`** — package updates

## Validation

The same `build` + `push` job pattern was validated end-to-end on `LayeredCraft/compact-json-formatter` with the same template version and composite action before applying here.

## Notes for Reviewers

NuGet.org trusted publisher entries for this repo will need to be configured pointing at `.github/workflows/publish-preview.yaml` and `.github/workflows/publish-release.yaml` before the push jobs will succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)